### PR TITLE
chore: change stale agent colour to yellow

### DIFF
--- a/App/Converters/AgentStatusToColorConverter.cs
+++ b/App/Converters/AgentStatusToColorConverter.cs
@@ -20,8 +20,8 @@ public class AgentStatusToColorConverter : IValueConverter
         return status switch
         {
             AgentConnectionStatus.Green => Green,
-            AgentConnectionStatus.Red => Red,
             AgentConnectionStatus.Yellow => Yellow,
+            AgentConnectionStatus.Red => Red,
             _ => Gray,
         };
     }

--- a/App/Converters/AgentStatusToColorConverter.cs
+++ b/App/Converters/AgentStatusToColorConverter.cs
@@ -11,6 +11,7 @@ public class AgentStatusToColorConverter : IValueConverter
     private static readonly SolidColorBrush Green = new(Color.FromArgb(255, 52, 199, 89));
     private static readonly SolidColorBrush Red = new(Color.FromArgb(255, 255, 59, 48));
     private static readonly SolidColorBrush Gray = new(Color.FromArgb(255, 142, 142, 147));
+    private static readonly SolidColorBrush Yellow = new(Color.FromArgb(255, 204, 1, 0));
 
     public object Convert(object value, Type targetType, object parameter, string language)
     {
@@ -20,6 +21,7 @@ public class AgentStatusToColorConverter : IValueConverter
         {
             AgentConnectionStatus.Green => Green,
             AgentConnectionStatus.Red => Red,
+            AgentConnectionStatus.Yellow => Yellow,
             _ => Gray,
         };
     }

--- a/App/Converters/AgentStatusToColorConverter.cs
+++ b/App/Converters/AgentStatusToColorConverter.cs
@@ -9,9 +9,9 @@ namespace Coder.Desktop.App.Converters;
 public class AgentStatusToColorConverter : IValueConverter
 {
     private static readonly SolidColorBrush Green = new(Color.FromArgb(255, 52, 199, 89));
+    private static readonly SolidColorBrush Yellow = new(Color.FromArgb(255, 204, 1, 0));
     private static readonly SolidColorBrush Red = new(Color.FromArgb(255, 255, 59, 48));
     private static readonly SolidColorBrush Gray = new(Color.FromArgb(255, 142, 142, 147));
-    private static readonly SolidColorBrush Yellow = new(Color.FromArgb(255, 204, 1, 0));
 
     public object Convert(object value, Type targetType, object parameter, string language)
     {

--- a/App/ViewModels/AgentViewModel.cs
+++ b/App/ViewModels/AgentViewModel.cs
@@ -10,6 +10,7 @@ public enum AgentConnectionStatus
 {
     Green,
     Red,
+    Yellow,
     Gray,
 }
 

--- a/App/ViewModels/AgentViewModel.cs
+++ b/App/ViewModels/AgentViewModel.cs
@@ -9,8 +9,8 @@ namespace Coder.Desktop.App.ViewModels;
 public enum AgentConnectionStatus
 {
     Green,
-    Red,
     Yellow,
+    Red,
     Gray,
 }
 

--- a/App/ViewModels/TrayWindowViewModel.cs
+++ b/App/ViewModels/TrayWindowViewModel.cs
@@ -137,7 +137,7 @@ public partial class TrayWindowViewModel : ObservableObject
                 HostnameSuffix = fqdnSuffix,
                 ConnectionStatus = lastHandshakeAgo < TimeSpan.FromMinutes(5)
                     ? AgentConnectionStatus.Green
-                    : AgentConnectionStatus.Red,
+                    : AgentConnectionStatus.Yellow,
                 DashboardUrl = WorkspaceUri(coderUri, workspace?.Name),
             });
         }


### PR DESCRIPTION
On the Mac app, we use Yellow when an agent's last handshake was longer than 5 minutes ago. We should reserve red for a more fatal error, rather than something that will show on every connection.