### PR TITLE
feat: include mutagen binary in installer

### DIFF
--- a/scripts/Publish.ps1
+++ b/scripts/Publish.ps1
@@ -85,6 +85,7 @@ function Add-CoderSignature([string] $path) {
 
 function Download-File([string] $url, [string] $outputPath, [string] $etagFile) {
     Write-Host "Downloading '$url' to '$outputPath'"
+    # We use `curl.exe` here because `Invoke-WebRequest` is notoriously slow.
     & curl.exe `
         --progress-bar `
         --show-error `
@@ -169,8 +170,7 @@ $wintunDllDest = Join-Path $vpnFilesPath "wintun.dll"
 Copy-Item $wintunDllSrc $wintunDllDest
 
 # Download the mutagen binary from our bucket for this platform if we don't have
-# it yet (or it's different). We use `curl.exe` here because `Invoke-WebRequest`
-# is notoriously slow.
+# it yet (or it's different).
 $mutagenVersion = "v0.18.1"
 $mutagenSrcPath = Join-Path $repoRoot "scripts\files\mutagen-windows-$($goArch).exe"
 $mutagenSrcUrl = "https://storage.googleapis.com/coder-desktop/mutagen/$($mutagenVersion)/mutagen-windows-$($goArch).exe"

--- a/scripts/files/.gitignore
+++ b/scripts/files/.gitignore
@@ -1,0 +1,3 @@
+mutagen-*.tar.gz
+mutagen-*.exe
+*.etag


### PR DESCRIPTION
`Publish.ps1` now downloads (if unmodified) the necessary mutagen files from our GCS bucket. These files aren't checked into the repo since they are large, but they will be cached and ignored in the workdir.

`mutagen.exe` and `mutagen-agents.tar.gz` will appear in the same directory as `wintun.dll` in the install.

```powershell
PS C:\Users\dean\git\coder-desktop-windows> ls .\publish\buildtemp-1.2.3.4-x64\vpn


    Directory: C:\Users\dean\git\coder-desktop-windows\publish\buildtemp-1.2.3.4-x64\vpn


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         1/03/2025     12:02           5431 LICENSE.WINTUN.txt
-a----        10/03/2025     11:58       17964207 mutagen-agents.tar.gz
-a----        10/03/2025     11:58       13797376 mutagen.exe
-a----         1/03/2025     15:20         427552 wintun.dll
```

Updating to a new mutagen version is as simple as updating `$mutagenVersion` in `Publish.ps1`.

Closes #25 