### PR TITLE
feat: add daemon service to MutagenSdk

### DIFF
--- a/MutagenSdk/MutagenClient.cs
+++ b/MutagenSdk/MutagenClient.cs
@@ -1,3 +1,4 @@
+using Coder.Desktop.MutagenSdk.Proto.Service.Daemon;
 using Coder.Desktop.MutagenSdk.Proto.Service.Synchronization;
 using Grpc.Core;
 using Grpc.Net.Client;
@@ -8,6 +9,7 @@ public class MutagenClient : IDisposable
 {
     private readonly GrpcChannel _channel;
 
+    public readonly Daemon.DaemonClient Daemon;
     public readonly Synchronization.SynchronizationClient Synchronization;
 
     public MutagenClient(string dataDir)
@@ -39,11 +41,15 @@ public class MutagenClient : IDisposable
             ConnectCallback = connectionFactory.ConnectAsync,
         };
 
+        // http://localhost is fake address. The HttpHandler will be used to
+        // open a socket to the named pipe.
         _channel = GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
         {
             Credentials = ChannelCredentials.Insecure,
             HttpHandler = socketsHttpHandler,
         });
+
+        Daemon = new Daemon.DaemonClient(_channel);
         Synchronization = new Synchronization.SynchronizationClient(_channel);
     }
 

--- a/MutagenSdk/Proto/filesystem/behavior/probe_mode.proto
+++ b/MutagenSdk/Proto/filesystem/behavior/probe_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/filesystem/behavior/probe_mode.proto
  *
@@ -48,4 +48,3 @@ enum ProbeMode {
     // ProbeMode_ProbeModeProbe.
     ProbeModeAssume = 2;
 }
-

--- a/MutagenSdk/Proto/selection/selection.proto
+++ b/MutagenSdk/Proto/selection/selection.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/selection/selection.proto
  *
@@ -45,4 +45,3 @@ message Selection {
     // it indicates that this selector should be used to select sessions.
     string labelSelector = 3;
 }
-

--- a/MutagenSdk/Proto/service/daemon/daemon.proto
+++ b/MutagenSdk/Proto/service/daemon/daemon.proto
@@ -1,6 +1,6 @@
 /*
  * This file was taken from
- * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/hashing/algorithm.proto
+ * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/service/daemon/daemon.proto
  *
  * MIT License
  *
@@ -27,21 +27,27 @@
 
 syntax = "proto3";
 
-package hashing;
-option csharp_namespace = "Coder.Desktop.MutagenSdk.Proto.Synchronization.Hashing";
+package daemon;
+option csharp_namespace = "Coder.Desktop.MutagenSdk.Proto.Service.Daemon";
 
-option go_package = "github.com/mutagen-io/mutagen/pkg/synchronization/hashing";
+option go_package = "github.com/mutagen-io/mutagen/pkg/service/daemon";
 
-// Algorithm specifies a hashing algorithm.
-enum Algorithm {
-    // Algorithm_AlgorithmDefault represents an unspecified hashing algorithm.
-    // It should be converted to one of the following values based on the
-    // desired default behavior.
-    AlgorithmDefault = 0;
-    // Algorithm_AlgorithmSHA1 specifies that SHA-1 hashing should be used.
-    AlgorithmSHA1 = 1;
-    // Algorithm_AlgorithmSHA256 specifies that SHA-256 hashing should be used.
-    AlgorithmSHA256 = 2;
-    // Algorithm_AlgorithmXXH128 specifies that XXH128 hashing should be used.
-    AlgorithmXXH128 = 3;
+message VersionRequest{}
+
+message VersionResponse {
+    // TODO: Should we encapsulate these inside a Version message type, perhaps
+    // in the mutagen package?
+    uint64 major = 1;
+    uint64 minor = 2;
+    uint64 patch = 3;
+    string tag = 4;
+}
+
+message TerminateRequest{}
+
+message TerminateResponse{}
+
+service Daemon {
+    rpc Version(VersionRequest) returns (VersionResponse) {}
+    rpc Terminate(TerminateRequest) returns (TerminateResponse) {}
 }

--- a/MutagenSdk/Proto/service/synchronization/synchronization.proto
+++ b/MutagenSdk/Proto/service/synchronization/synchronization.proto
@@ -1,6 +1,6 @@
-﻿/*
+/*
  * This file was taken from
- * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/service\synchronization\synchronization.proto
+ * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/service/synchronization/synchronization.proto
  *
  * MIT License
  *
@@ -167,4 +167,3 @@ service Synchronization {
     // Terminate terminates sessions.
     rpc Terminate(TerminateRequest) returns (TerminateResponse) {}
 }
-

--- a/MutagenSdk/Proto/synchronization/compression/algorithm.proto
+++ b/MutagenSdk/Proto/synchronization/compression/algorithm.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/compression/algorithm.proto
  *
@@ -47,4 +47,3 @@ enum Algorithm {
     // be used.
     AlgorithmZstandard = 3;
 }
-

--- a/MutagenSdk/Proto/synchronization/configuration.proto
+++ b/MutagenSdk/Proto/synchronization/configuration.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/configuration.proto
  *
@@ -173,4 +173,3 @@ message Configuration {
     // Fields 82-90 are reserved for future compression configuration
     // parameters.
 }
-

--- a/MutagenSdk/Proto/synchronization/core/change.proto
+++ b/MutagenSdk/Proto/synchronization/core/change.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/change.proto
  *
@@ -47,4 +47,3 @@ message Change {
     // nil if content has been deleted.
     Entry new = 3;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/conflict.proto
+++ b/MutagenSdk/Proto/synchronization/core/conflict.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/conflict.proto
  *
@@ -51,4 +51,3 @@ message Conflict {
     // BetaChanges are the relevant changes on beta.
     repeated Change betaChanges = 3;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/entry.proto
+++ b/MutagenSdk/Proto/synchronization/core/entry.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/entry.proto
  *
@@ -108,4 +108,3 @@ message Entry {
     // non-empty if and only if the entry represents problematic content.
     string problem = 15;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/ignore/ignore_vcs_mode.proto
+++ b/MutagenSdk/Proto/synchronization/core/ignore/ignore_vcs_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/ignore/ignore_vcs_mode.proto
  *
@@ -45,4 +45,3 @@ enum IgnoreVCSMode {
     // should be propagated.
     IgnoreVCSModePropagate = 2;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/ignore/syntax.proto
+++ b/MutagenSdk/Proto/synchronization/core/ignore/syntax.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/ignore/syntax.proto
  *
@@ -45,4 +45,3 @@ enum Syntax {
     // semantics should be used.
     SyntaxDocker = 2;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/mode.proto
+++ b/MutagenSdk/Proto/synchronization/core/mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/mode.proto
  *
@@ -68,4 +68,3 @@ enum SynchronizationMode {
     // deleting any extraneous contents on beta.
     SynchronizationModeOneWayReplica = 4;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/permissions_mode.proto
+++ b/MutagenSdk/Proto/synchronization/core/permissions_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/permissions_mode.proto
  *
@@ -49,4 +49,3 @@ enum PermissionsMode {
     // perform any propagation of permissions.
     PermissionsModeManual = 2;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/problem.proto
+++ b/MutagenSdk/Proto/synchronization/core/problem.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/problem.proto
  *
@@ -42,4 +42,3 @@ message Problem {
     // Error is a human-readable summary of the problem.
     string error = 2;
 }
-

--- a/MutagenSdk/Proto/synchronization/core/symbolic_link_mode.proto
+++ b/MutagenSdk/Proto/synchronization/core/symbolic_link_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/core/symbolic_link_mode.proto
  *
@@ -52,4 +52,3 @@ enum SymbolicLinkMode {
     // and only makes sense in the context of POSIX-to-POSIX synchronization.
     SymbolicLinkModePOSIXRaw = 3;
 }
-

--- a/MutagenSdk/Proto/synchronization/rsync/receive.proto
+++ b/MutagenSdk/Proto/synchronization/rsync/receive.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/rsync/receive.proto
  *
@@ -55,4 +55,3 @@ message ReceiverState {
     // It would also be really nice to have TotalExpectedSize, but this is
     // prohibitively difficult and expensive to compute.
 }
-

--- a/MutagenSdk/Proto/synchronization/scan_mode.proto
+++ b/MutagenSdk/Proto/synchronization/scan_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/scan_mode.proto
  *
@@ -45,4 +45,3 @@ enum ScanMode {
     // watch-based acceleration.
     ScanModeAccelerated = 2;
 }
-

--- a/MutagenSdk/Proto/synchronization/session.proto
+++ b/MutagenSdk/Proto/synchronization/session.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/session.proto
  *
@@ -99,4 +99,3 @@ message Session {
     // NOTE: Fields 11, 12, 13, and 14 are used above. They are out of order for
     // historical reasons.
 }
-

--- a/MutagenSdk/Proto/synchronization/stage_mode.proto
+++ b/MutagenSdk/Proto/synchronization/stage_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/stage_mode.proto
  *
@@ -49,4 +49,3 @@ enum StageMode {
     // function if the synchronization root already exists.
     StageModeInternal = 3;
 }
-

--- a/MutagenSdk/Proto/synchronization/state.proto
+++ b/MutagenSdk/Proto/synchronization/state.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/state.proto
  *
@@ -158,4 +158,3 @@ message State {
     // BetaState encodes the state of the beta endpoint. It is always non-nil.
     EndpointState betaState = 8;
 }
-

--- a/MutagenSdk/Proto/synchronization/version.proto
+++ b/MutagenSdk/Proto/synchronization/version.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/version.proto
  *
@@ -42,4 +42,3 @@ enum Version {
     // Version1 represents session version 1.
     Version1 = 1;
 }
-

--- a/MutagenSdk/Proto/synchronization/watch_mode.proto
+++ b/MutagenSdk/Proto/synchronization/watch_mode.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/synchronization/watch_mode.proto
  *
@@ -52,4 +52,3 @@ enum WatchMode {
     // (i.e. no events should be generated).
     WatchModeNoWatch = 3;
 }
-

--- a/MutagenSdk/Proto/url/url.proto
+++ b/MutagenSdk/Proto/url/url.proto
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file was taken from
  * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/url/url.proto
  *
@@ -89,4 +89,3 @@ message URL {
     // required and their behavior is dependent on the transport implementation.
     map<string, string> parameters = 8;
 }
-


### PR DESCRIPTION
- Adds support for an array of protobuf "entry points" in `Mutagen/Update-Proto.ps1`
    - Also refactors file modification/writing to be more efficient and to not include an unnecessary byte order mark and two trailing new lines
- Adds Daemon service to `MutagenClient`