### PR TITLE
feat: wire up file sync window

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -120,7 +120,7 @@ public partial class App : Application
         // Initialize file sync.
         var syncSessionCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var syncSessionController = _services.GetRequiredService<ISyncSessionController>();
-        _ = syncSessionController.Initialize(syncSessionCts.Token).ContinueWith(t =>
+        _ = syncSessionController.RefreshState(syncSessionCts.Token).ContinueWith(t =>
         {
             // TODO: log
 #if DEBUG

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Coder.Desktop.App.Models;
@@ -73,6 +74,8 @@ public partial class App : Application
     {
         _handleWindowClosed = false;
         Exit();
+        var syncController = _services.GetRequiredService<ISyncSessionController>();
+        await syncController.DisposeAsync();
         var rpcController = _services.GetRequiredService<IRpcController>();
         // TODO: send a StopRequest if we're connected???
         await rpcController.DisposeAsync();
@@ -86,20 +89,52 @@ public partial class App : Application
         if (rpcController.GetState().RpcLifecycle == RpcLifecycle.Disconnected)
             // Passing in a CT with no cancellation is desired here, because
             // the named pipe open will block until the pipe comes up.
-            _ = rpcController.Reconnect(CancellationToken.None);
+            // TODO: log
+            _ = rpcController.Reconnect(CancellationToken.None).ContinueWith(t =>
+            {
+#if DEBUG
+                if (t.Exception != null)
+                {
+                    Debug.WriteLine(t.Exception);
+                    Debugger.Break();
+                }
+#endif
+            });
 
-        // Load the credentials in the background. Even though we pass a CT
-        // with no cancellation, the method itself will impose a timeout on the
-        // HTTP portion.
+        // Load the credentials in the background.
+        var credentialManagerCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         var credentialManager = _services.GetRequiredService<ICredentialManager>();
-        _ = credentialManager.LoadCredentials(CancellationToken.None);
+        _ = credentialManager.LoadCredentials(credentialManagerCts.Token).ContinueWith(t =>
+        {
+            // TODO: log
+#if DEBUG
+            if (t.Exception != null)
+            {
+                Debug.WriteLine(t.Exception);
+                Debugger.Break();
+            }
+#endif
+            credentialManagerCts.Dispose();
+        }, CancellationToken.None);
+
+        // Initialize file sync.
+        var syncSessionCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var syncSessionController = _services.GetRequiredService<ISyncSessionController>();
+        _ = syncSessionController.Initialize(syncSessionCts.Token).ContinueWith(t =>
+        {
+            // TODO: log
+#if DEBUG
+            if (t.IsCanceled || t.Exception != null) Debugger.Break();
+#endif
+            syncSessionCts.Dispose();
+        }, CancellationToken.None);
 
         // Prevent the TrayWindow from closing, just hide it.
         var trayWindow = _services.GetRequiredService<TrayWindow>();
-        trayWindow.Closed += (sender, args) =>
+        trayWindow.Closed += (_, closedArgs) =>
         {
             if (!_handleWindowClosed) return;
-            args.Handled = true;
+            closedArgs.Handled = true;
             trayWindow.AppWindow.Hide();
         };
     }

--- a/App/Models/RpcModel.cs
+++ b/App/Models/RpcModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Coder.Desktop.Vpn.Proto;
 
 namespace Coder.Desktop.App.Models;
@@ -26,9 +25,9 @@ public class RpcModel
 
     public VpnLifecycle VpnLifecycle { get; set; } = VpnLifecycle.Unknown;
 
-    public List<Workspace> Workspaces { get; set; } = [];
+    public IReadOnlyList<Workspace> Workspaces { get; set; } = [];
 
-    public List<Agent> Agents { get; set; } = [];
+    public IReadOnlyList<Agent> Agents { get; set; } = [];
 
     public RpcModel Clone()
     {
@@ -36,8 +35,8 @@ public class RpcModel
         {
             RpcLifecycle = RpcLifecycle,
             VpnLifecycle = VpnLifecycle,
-            Workspaces = Workspaces.ToList(),
-            Agents = Agents.ToList(),
+            Workspaces = Workspaces,
+            Agents = Agents,
         };
     }
 }

--- a/App/Models/SyncSessionControllerStateModel.cs
+++ b/App/Models/SyncSessionControllerStateModel.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace Coder.Desktop.App.Models;
+
+public enum SyncSessionControllerLifecycle
+{
+    // Uninitialized means that the daemon has not been started yet. This can
+    // be resolved by calling RefreshState (or any other RPC method
+    // successfully).
+    Uninitialized,
+
+    // Stopped means that the daemon is not running. This could be because:
+    // - It was never started (pre-Initialize)
+    // - It was stopped due to no sync sessions (post-Initialize, post-operation)
+    // - The last start attempt failed (DaemonError will be set)
+    // - The last daemon process crashed (DaemonError will be set)
+    Stopped,
+
+    // Running is the normal state where the daemon is running and managing
+    // sync sessions. This is only set after a successful start (including
+    // being able to connect to the daemon).
+    Running,
+}
+
+public class SyncSessionControllerStateModel
+{
+    public SyncSessionControllerLifecycle Lifecycle { get; init; } = SyncSessionControllerLifecycle.Stopped;
+
+    /// <summary>
+    ///     May be set when Lifecycle is Stopped to signify that the daemon failed
+    ///     to start or unexpectedly crashed.
+    /// </summary>
+    public string? DaemonError { get; init; }
+
+    public required string DaemonLogFilePath { get; init; }
+
+    /// <summary>
+    ///     This contains the last known state of all sync sessions. Sync sessions
+    ///     are periodically refreshed if the daemon is running. This list is
+    ///     sorted by creation time.
+    /// </summary>
+    public IReadOnlyList<SyncSessionModel> SyncSessions { get; init; } = [];
+}

--- a/App/Models/SyncSessionModel.cs
+++ b/App/Models/SyncSessionModel.cs
@@ -51,6 +51,7 @@ public sealed class SyncSessionModelEndpointSize
 public class SyncSessionModel
 {
     public readonly string Identifier;
+    public readonly DateTime CreatedAt;
 
     public readonly string AlphaName;
     public readonly string AlphaPath;
@@ -99,6 +100,7 @@ public class SyncSessionModel
     public SyncSessionModel(State state)
     {
         Identifier = state.Session.Identifier;
+        CreatedAt = state.Session.CreationTime.ToDateTime();
 
         (AlphaName, AlphaPath) = NameAndPathFromUrl(state.Session.Alpha);
         (BetaName, BetaPath) = NameAndPathFromUrl(state.Session.Beta);

--- a/App/Models/SyncSessionModel.cs
+++ b/App/Models/SyncSessionModel.cs
@@ -1,4 +1,3 @@
-using System;
 using Coder.Desktop.App.Converters;
 using Coder.Desktop.MutagenSdk.Proto.Synchronization;
 using Coder.Desktop.MutagenSdk.Proto.Url;
@@ -64,6 +63,10 @@ public class SyncSessionModel
 
     public readonly string[] Errors = [];
 
+    // If Paused is true, the session can be resumed. If false, the session can
+    // be paused.
+    public bool Paused => StatusCategory is SyncSessionStatusCategory.Paused or SyncSessionStatusCategory.Halted;
+
     public string StatusDetails
     {
         get
@@ -82,37 +85,6 @@ public class SyncSessionModel
                       "Remote:\n" + BetaSize.Description("  ");
             return str;
         }
-    }
-
-    // TODO: remove once we process sessions from the mutagen RPC
-    public SyncSessionModel(string alphaPath, string betaName, string betaPath,
-        SyncSessionStatusCategory statusCategory,
-        string statusString, string statusDescription, string[] errors)
-    {
-        Identifier = "TODO";
-        Name = "TODO";
-
-        AlphaName = "Local";
-        AlphaPath = alphaPath;
-        BetaName = betaName;
-        BetaPath = betaPath;
-        StatusCategory = statusCategory;
-        StatusString = statusString;
-        StatusDescription = statusDescription;
-        AlphaSize = new SyncSessionModelEndpointSize
-        {
-            SizeBytes = (ulong)new Random().Next(0, 1000000000),
-            FileCount = (ulong)new Random().Next(0, 10000),
-            DirCount = (ulong)new Random().Next(0, 10000),
-        };
-        BetaSize = new SyncSessionModelEndpointSize
-        {
-            SizeBytes = (ulong)new Random().Next(0, 1000000000),
-            FileCount = (ulong)new Random().Next(0, 10000),
-            DirCount = (ulong)new Random().Next(0, 10000),
-        };
-
-        Errors = errors;
     }
 
     public SyncSessionModel(State state)

--- a/App/Models/SyncSessionModel.cs
+++ b/App/Models/SyncSessionModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using Coder.Desktop.App.Converters;
 using Coder.Desktop.MutagenSdk.Proto.Synchronization;
@@ -49,163 +48,9 @@ public sealed class SyncSessionModelEndpointSize
     }
 }
 
-public enum SyncSessionModelEntryKind
-{
-    Unknown,
-    Directory,
-    File,
-    SymbolicLink,
-    Untracked,
-    Problematic,
-    PhantomDirectory,
-}
-
-public sealed class SyncSessionModelEntry
-{
-    public readonly SyncSessionModelEntryKind Kind;
-
-    // For Kind == Directory only.
-    public readonly ReadOnlyDictionary<string, SyncSessionModelEntry> Contents;
-
-    // For Kind == File only.
-    public readonly string Digest = "";
-    public readonly bool Executable;
-
-    // For Kind = SymbolicLink only.
-    public readonly string Target = "";
-
-    // For Kind = Problematic only.
-    public readonly string Problem = "";
-
-    public SyncSessionModelEntry(Entry protoEntry)
-    {
-        Kind = protoEntry.Kind switch
-        {
-            EntryKind.Directory => SyncSessionModelEntryKind.Directory,
-            EntryKind.File => SyncSessionModelEntryKind.File,
-            EntryKind.SymbolicLink => SyncSessionModelEntryKind.SymbolicLink,
-            EntryKind.Untracked => SyncSessionModelEntryKind.Untracked,
-            EntryKind.Problematic => SyncSessionModelEntryKind.Problematic,
-            EntryKind.PhantomDirectory => SyncSessionModelEntryKind.PhantomDirectory,
-            _ => SyncSessionModelEntryKind.Unknown,
-        };
-
-        switch (Kind)
-        {
-            case SyncSessionModelEntryKind.Directory:
-            {
-                var contents = new Dictionary<string, SyncSessionModelEntry>();
-                foreach (var (key, value) in protoEntry.Contents)
-                    contents[key] = new SyncSessionModelEntry(value);
-                Contents = new ReadOnlyDictionary<string, SyncSessionModelEntry>(contents);
-                break;
-            }
-            case SyncSessionModelEntryKind.File:
-                Digest = BitConverter.ToString(protoEntry.Digest.ToByteArray()).Replace("-", "").ToLower();
-                Executable = protoEntry.Executable;
-                break;
-            case SyncSessionModelEntryKind.SymbolicLink:
-                Target = protoEntry.Target;
-                break;
-            case SyncSessionModelEntryKind.Problematic:
-                Problem = protoEntry.Problem;
-                break;
-        }
-    }
-
-    public new string ToString()
-    {
-        var str = Kind.ToString();
-        switch (Kind)
-        {
-            case SyncSessionModelEntryKind.Directory:
-                str += $" ({Contents.Count} entries)";
-                break;
-            case SyncSessionModelEntryKind.File:
-                str += $" ({Digest}, executable: {Executable})";
-                break;
-            case SyncSessionModelEntryKind.SymbolicLink:
-                str += $" (target: {Target})";
-                break;
-            case SyncSessionModelEntryKind.Problematic:
-                str += $" ({Problem})";
-                break;
-        }
-
-        return str;
-    }
-}
-
-public sealed class SyncSessionModelConflictChange
-{
-    public readonly string Path; // relative to sync root
-
-    // null means non-existent:
-    public readonly SyncSessionModelEntry? Old;
-    public readonly SyncSessionModelEntry? New;
-
-    public SyncSessionModelConflictChange(Change protoChange)
-    {
-        Path = protoChange.Path;
-        Old = protoChange.Old != null ? new SyncSessionModelEntry(protoChange.Old) : null;
-        New = protoChange.New != null ? new SyncSessionModelEntry(protoChange.New) : null;
-    }
-
-    public new string ToString()
-    {
-        const string nonExistent = "<non-existent>";
-        var oldStr = Old != null ? Old.ToString() : nonExistent;
-        var newStr = New != null ? New.ToString() : nonExistent;
-        return $"{Path} ({oldStr} -> {newStr})";
-    }
-}
-
-public sealed class SyncSessionModelConflict
-{
-    public readonly string Root; // relative to sync root
-    public readonly List<SyncSessionModelConflictChange> AlphaChanges;
-    public readonly List<SyncSessionModelConflictChange> BetaChanges;
-
-    public SyncSessionModelConflict(Conflict protoConflict)
-    {
-        Root = protoConflict.Root;
-        AlphaChanges = protoConflict.AlphaChanges.Select(change => new SyncSessionModelConflictChange(change)).ToList();
-        BetaChanges = protoConflict.BetaChanges.Select(change => new SyncSessionModelConflictChange(change)).ToList();
-    }
-
-    private string? FriendlyProblem()
-    {
-        // If the change is <non-existent> -> !<non-existent>.
-        if (AlphaChanges.Count == 1 && BetaChanges.Count == 1 &&
-            AlphaChanges[0].Old == null &&
-            BetaChanges[0].Old == null &&
-            AlphaChanges[0].New != null &&
-            BetaChanges[0].New != null)
-            return
-                "An entry was created on both endpoints and they do not match. You can resolve this conflict by deleting one of the entries on either side.";
-
-        return null;
-    }
-
-    public string Description()
-    {
-        // This formatting is very similar to Mutagen.
-        var str = $"Conflict at path '{Root}':";
-        foreach (var change in AlphaChanges)
-            str += $"\n  (alpha) {change.ToString()}";
-        foreach (var change in AlphaChanges)
-            str += $"\n  (beta)  {change.ToString()}";
-        if (FriendlyProblem() is { } friendlyProblem)
-            str += $"\n\n  {friendlyProblem}";
-
-        return str;
-    }
-}
-
 public class SyncSessionModel
 {
     public readonly string Identifier;
-    public readonly string Name;
 
     public readonly string AlphaName;
     public readonly string AlphaPath;
@@ -219,8 +64,8 @@ public class SyncSessionModel
     public readonly SyncSessionModelEndpointSize AlphaSize;
     public readonly SyncSessionModelEndpointSize BetaSize;
 
-    public readonly IReadOnlyList<SyncSessionModelConflict> Conflicts;
-    public ulong OmittedConflicts;
+    public readonly IReadOnlyList<string> Conflicts; // Conflict descriptions
+    public readonly ulong OmittedConflicts;
     public readonly IReadOnlyList<string> Errors;
 
     // If Paused is true, the session can be resumed. If false, the session can
@@ -231,10 +76,12 @@ public class SyncSessionModel
     {
         get
         {
-            var str = $"{StatusString} ({StatusCategory})\n\n{StatusDescription}";
-            foreach (var err in Errors) str += $"\n\nError: {err}";
-            foreach (var conflict in Conflicts) str += $"\n\n{conflict.Description()}";
-            if (OmittedConflicts > 0) str += $"\n\n{OmittedConflicts:N0} conflicts omitted";
+            var str = StatusString;
+            if (StatusCategory.ToString() != StatusString) str += $" ({StatusCategory})";
+            str += $"\n\n{StatusDescription}";
+            foreach (var err in Errors) str += $"\n\n-----\n\n{err}";
+            foreach (var conflict in Conflicts) str += $"\n\n-----\n\n{conflict}";
+            if (OmittedConflicts > 0) str += $"\n\n-----\n\n{OmittedConflicts:N0} conflicts omitted";
             return str;
         }
     }
@@ -252,7 +99,6 @@ public class SyncSessionModel
     public SyncSessionModel(State state)
     {
         Identifier = state.Session.Identifier;
-        Name = state.Session.Name;
 
         (AlphaName, AlphaPath) = NameAndPathFromUrl(state.Session.Alpha);
         (BetaName, BetaPath) = NameAndPathFromUrl(state.Session.Beta);
@@ -354,7 +200,7 @@ public class SyncSessionModel
             StatusDescription = "The session has conflicts that need to be resolved.";
         }
 
-        Conflicts = state.Conflicts.Select(c => new SyncSessionModelConflict(c)).ToList();
+        Conflicts = state.Conflicts.Select(ConflictToString).ToList();
         OmittedConflicts = state.ExcludedConflicts;
 
         AlphaSize = new SyncSessionModelEndpointSize
@@ -402,5 +248,56 @@ public class SyncSessionModel
         if (string.IsNullOrWhiteSpace(url.Host)) name = url.Host;
 
         return (name, path);
+    }
+
+    private static string ConflictToString(Conflict conflict)
+    {
+        string? friendlyProblem = null;
+        if (conflict.AlphaChanges.Count == 1 && conflict.BetaChanges.Count == 1 &&
+            conflict.AlphaChanges[0].Old == null &&
+            conflict.BetaChanges[0].Old == null &&
+            conflict.AlphaChanges[0].New != null &&
+            conflict.BetaChanges[0].New != null)
+            friendlyProblem =
+                "An entry was created on both endpoints and they do not match. You can resolve this conflict by deleting one of the entries on either side.";
+
+        var str = $"Conflict at path '{conflict.Root}':";
+        foreach (var change in conflict.AlphaChanges)
+            str += $"\n  (alpha) {ChangeToString(change)}";
+        foreach (var change in conflict.BetaChanges)
+            str += $"\n  (beta)  {ChangeToString(change)}";
+        if (friendlyProblem != null)
+            str += $"\n\n{friendlyProblem}";
+
+        return str;
+    }
+
+    private static string ChangeToString(Change change)
+    {
+        return $"{change.Path} ({EntryToString(change.Old)} -> {EntryToString(change.New)})";
+    }
+
+    private static string EntryToString(Entry? entry)
+    {
+        if (entry == null) return "<non-existent>";
+        var str = entry.Kind.ToString();
+        switch (entry.Kind)
+        {
+            case EntryKind.Directory:
+                str += $" ({entry.Contents.Count} entries)";
+                break;
+            case EntryKind.File:
+                var digest = BitConverter.ToString(entry.Digest.ToByteArray()).Replace("-", "").ToLower();
+                str += $" ({digest}, executable: {entry.Executable})";
+                break;
+            case EntryKind.SymbolicLink:
+                str += $" (target: {entry.Target})";
+                break;
+            case EntryKind.Problematic:
+                str += $" ({entry.Problem})";
+                break;
+        }
+
+        return str;
     }
 }

--- a/App/Services/MutagenController.cs
+++ b/App/Services/MutagenController.cs
@@ -23,48 +23,48 @@ using SynchronizationTerminateRequest = Coder.Desktop.MutagenSdk.Proto.Service.S
 
 namespace Coder.Desktop.App.Services;
 
-public enum CreateSyncSessionRequestEndpointProtocol
-{
-    Local,
-    Ssh,
-}
-
-public class CreateSyncSessionRequestEndpoint
-{
-    public required CreateSyncSessionRequestEndpointProtocol Protocol { get; init; }
-    public string User { get; init; } = "";
-    public string Host { get; init; } = "";
-    public uint Port { get; init; } = 0;
-    public string Path { get; init; } = "";
-
-    public URL MutagenUrl
-    {
-        get
-        {
-            var protocol = Protocol switch
-            {
-                CreateSyncSessionRequestEndpointProtocol.Local => MutagenProtocol.Local,
-                CreateSyncSessionRequestEndpointProtocol.Ssh => MutagenProtocol.Ssh,
-                _ => throw new ArgumentException($"Invalid protocol '{Protocol}'", nameof(Protocol)),
-            };
-
-            return new URL
-            {
-                Kind = Kind.Synchronization,
-                Protocol = protocol,
-                User = User,
-                Host = Host,
-                Port = Port,
-                Path = Path,
-            };
-        }
-    }
-}
-
 public class CreateSyncSessionRequest
 {
-    public required CreateSyncSessionRequestEndpoint Alpha { get; init; }
-    public required CreateSyncSessionRequestEndpoint Beta { get; init; }
+    public required Endpoint Alpha { get; init; }
+    public required Endpoint Beta { get; init; }
+
+    public class Endpoint
+    {
+        public enum ProtocolKind
+        {
+            Local,
+            Ssh,
+        }
+
+        public required ProtocolKind Protocol { get; init; }
+        public string User { get; init; } = "";
+        public string Host { get; init; } = "";
+        public uint Port { get; init; } = 0;
+        public string Path { get; init; } = "";
+
+        public URL MutagenUrl
+        {
+            get
+            {
+                var protocol = Protocol switch
+                {
+                    ProtocolKind.Local => MutagenProtocol.Local,
+                    ProtocolKind.Ssh => MutagenProtocol.Ssh,
+                    _ => throw new ArgumentException($"Invalid protocol '{Protocol}'", nameof(Protocol)),
+                };
+
+                return new URL
+                {
+                    Kind = Kind.Synchronization,
+                    Protocol = protocol,
+                    User = User,
+                    Host = Host,
+                    Port = Port,
+                    Path = Path,
+                };
+            }
+        }
+    }
 }
 
 public interface ISyncSessionController : IAsyncDisposable

--- a/App/Services/MutagenController.cs
+++ b/App/Services/MutagenController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.IO;
@@ -69,17 +68,27 @@ public class CreateSyncSessionRequest
 
 public interface ISyncSessionController : IAsyncDisposable
 {
-    Task<IEnumerable<SyncSessionModel>> ListSyncSessions(CancellationToken ct = default);
+    public event EventHandler<SyncSessionControllerStateModel> StateChanged;
+
+    /// <summary>
+    ///     Gets the current state of the controller.
+    /// </summary>
+    SyncSessionControllerStateModel GetState();
+
+    // All the following methods will raise a StateChanged event *BEFORE* they return.
+
+    /// <summary>
+    ///     Starts the daemon (if it's not running) and fully refreshes the state of the controller. This should be
+    ///     called at startup and after any unexpected daemon crashes to attempt to retry.
+    ///     Additionally, the first call to RefreshState will start a background task to keep the state up-to-date while
+    ///     the daemon is running.
+    /// </summary>
+    Task<SyncSessionControllerStateModel> RefreshState(CancellationToken ct = default);
+
     Task<SyncSessionModel> CreateSyncSession(CreateSyncSessionRequest req, CancellationToken ct = default);
     Task<SyncSessionModel> PauseSyncSession(string identifier, CancellationToken ct = default);
     Task<SyncSessionModel> ResumeSyncSession(string identifier, CancellationToken ct = default);
     Task TerminateSyncSession(string identifier, CancellationToken ct = default);
-
-    // <summary>
-    // Initializes the controller; running the daemon if there are any saved sessions. Must be called and
-    // complete before other methods are allowed.
-    // </summary>
-    Task Initialize(CancellationToken ct = default);
 }
 
 // These values are the config option names used in the registry. Any option
@@ -89,35 +98,33 @@ public interface ISyncSessionController : IAsyncDisposable
 // If changed here, they should also be changed in the installer.
 public class MutagenControllerConfig
 {
+    // This is set to "[INSTALLFOLDER]\vpn\mutagen.exe" by the installer.
     [Required] public string MutagenExecutablePath { get; set; } = @"c:\mutagen.exe";
 }
 
-// <summary>
-// A file synchronization controller based on the Mutagen Daemon.
-// </summary>
-public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
+/// <summary>
+///     A file synchronization controller based on the Mutagen Daemon.
+/// </summary>
+public sealed class MutagenController : ISyncSessionController
 {
-    // Lock to protect all non-readonly class members.
+    // Protects all private non-readonly class members.
     private readonly RaiiSemaphoreSlim _lock = new(1, 1);
 
-    // daemonProcess is non-null while the daemon is running, starting, or
+    private readonly CancellationTokenSource _stateUpdateCts = new();
+    private Task? _stateUpdateTask;
+
+    // _state is the current state of the controller. It is updated
+    // continuously while the daemon is running and after most operations.
+    private SyncSessionControllerStateModel? _state;
+
+    // _daemonProcess is non-null while the daemon is running, starting, or
     // in the process of stopping.
     private Process? _daemonProcess;
 
     private LogWriter? _logWriter;
 
-    // holds an in-progress task starting or stopping the daemon. If task is null,
-    // then we are not starting or stopping, and the _daemonProcess will be null if
-    // the daemon is currently stopped. If the task is not null, the daemon is
-    // starting or stopping. If stopping, the result is null.
-    private Task<MutagenClient?>? _inProgressTransition;
-
     // holds a client connected to the running mutagen daemon, if the daemon is running.
     private MutagenClient? _mutagenClient;
-
-    // holds a local count of SyncSessions, primarily so we can tell when to shut down
-    // the daemon because it is unneeded.
-    private int _sessionCount = -1;
 
     // set to true if we are disposing the controller. Prevents the daemon from being
     // restarted.
@@ -130,6 +137,8 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         "CoderDesktop",
         "mutagen");
 
+    private string MutagenDaemonLog => Path.Combine(_mutagenDataDirectory, "daemon.log");
+
     public MutagenController(IOptions<MutagenControllerConfig> config)
     {
         _mutagenExecutablePath = config.Value.MutagenExecutablePath;
@@ -141,28 +150,62 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         _mutagenDataDirectory = dataDirectory;
     }
 
+    public event EventHandler<SyncSessionControllerStateModel>? StateChanged;
+
     public async ValueTask DisposeAsync()
     {
-        Task<MutagenClient?>? transition;
-        using (_ = await _lock.LockAsync(CancellationToken.None))
-        {
-            _disposing = true;
-            if (_inProgressTransition == null && _daemonProcess == null && _mutagenClient == null) return;
-            transition = _inProgressTransition;
-        }
+        using var _ = await _lock.LockAsync(CancellationToken.None);
+        _disposing = true;
 
-        if (transition != null) await transition;
-        await StopDaemon(new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
+        await _stateUpdateCts.CancelAsync();
+        if (_stateUpdateTask != null)
+            try
+            {
+                await _stateUpdateTask;
+            }
+            catch
+            {
+                // ignored
+            }
+
+        _stateUpdateCts.Dispose();
+
+        using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await StopDaemon(stopCts.Token);
+
         GC.SuppressFinalize(this);
+    }
+
+    public SyncSessionControllerStateModel GetState()
+    {
+        // No lock required to read the reference.
+        var state = _state;
+        // No clone needed as the model is immutable.
+        if (state != null) return state;
+        return new SyncSessionControllerStateModel
+        {
+            Lifecycle = SyncSessionControllerLifecycle.Uninitialized,
+            DaemonError = null,
+            DaemonLogFilePath = MutagenDaemonLog,
+            SyncSessions = [],
+        };
+    }
+
+    public async Task<SyncSessionControllerStateModel> RefreshState(CancellationToken ct = default)
+    {
+        using var _ = await _lock.LockAsync(ct);
+        var client = await EnsureDaemon(ct);
+        var state = await UpdateState(client, ct);
+        _stateUpdateTask ??= UpdateLoop(_stateUpdateCts.Token);
+        return state;
     }
 
     public async Task<SyncSessionModel> CreateSyncSession(CreateSyncSessionRequest req, CancellationToken ct = default)
     {
-        // reads of _sessionCount are atomic, so don't bother locking for this quick check.
-        if (_sessionCount == -1) throw new InvalidOperationException("Controller must be Initialized first");
+        using var _ = await _lock.LockAsync(ct);
         var client = await EnsureDaemon(ct);
 
-        await using var prompter = await CreatePrompter(client, true, ct);
+        await using var prompter = await Prompter.Create(client, true, ct);
         var createRes = await client.Synchronization.CreateAsync(new CreateRequest
         {
             Prompter = prompter.Identifier,
@@ -178,36 +221,19 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         }, cancellationToken: ct);
         if (createRes == null) throw new InvalidOperationException("CreateAsync returned null");
 
-        // Increment session count early, to avoid list failures interfering
-        // with the count.
-        using (_ = await _lock.LockAsync(ct))
-        {
-            _sessionCount += 1;
-        }
-
-        var listRes = await client.Synchronization.ListAsync(new ListRequest
-        {
-            Selection = new Selection
-            {
-                Specifications = { createRes.Session },
-            },
-        }, cancellationToken: ct);
-        if (listRes == null) throw new InvalidOperationException("ListAsync returned null");
-        if (listRes.SessionStates.Count != 1)
-            throw new InvalidOperationException("ListAsync returned wrong number of sessions");
-
-        return new SyncSessionModel(listRes.SessionStates[0]);
+        var session = await GetSyncSession(client, createRes.Session, ct);
+        await UpdateState(client, ct);
+        return session;
     }
 
     public async Task<SyncSessionModel> PauseSyncSession(string identifier, CancellationToken ct = default)
     {
-        // reads of _sessionCount are atomic, so don't bother locking for this quick check.
-        if (_sessionCount == -1) throw new InvalidOperationException("Controller must be Initialized first");
+        using var _ = await _lock.LockAsync(ct);
         var client = await EnsureDaemon(ct);
 
         // Pausing sessions doesn't require prompting as seen in the mutagen CLI.
-        await using var prompter = await CreatePrompter(client, false, ct);
-        _ = await client.Synchronization.PauseAsync(new PauseRequest
+        await using var prompter = await Prompter.Create(client, false, ct);
+        await client.Synchronization.PauseAsync(new PauseRequest
         {
             Prompter = prompter.Identifier,
             Selection = new Selection
@@ -216,29 +242,18 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             },
         }, cancellationToken: ct);
 
-        var listRes = await client.Synchronization.ListAsync(new ListRequest
-        {
-            Selection = new Selection
-            {
-                Specifications = { identifier },
-            },
-        }, cancellationToken: ct);
-        if (listRes == null) throw new InvalidOperationException("ListAsync returned null");
-        if (listRes.SessionStates.Count != 1)
-            throw new InvalidOperationException("ListAsync returned wrong number of sessions");
-
-        return new SyncSessionModel(listRes.SessionStates[0]);
+        var session = await GetSyncSession(client, identifier, ct);
+        await UpdateState(client, ct);
+        return session;
     }
 
     public async Task<SyncSessionModel> ResumeSyncSession(string identifier, CancellationToken ct = default)
     {
-        // reads of _sessionCount are atomic, so don't bother locking for this quick check.
-        if (_sessionCount == -1) throw new InvalidOperationException("Controller must be Initialized first");
+        using var _ = await _lock.LockAsync(ct);
         var client = await EnsureDaemon(ct);
 
-        // Resuming sessions doesn't require prompting as seen in the mutagen CLI.
-        await using var prompter = await CreatePrompter(client, false, ct);
-        _ = await client.Synchronization.ResumeAsync(new ResumeRequest
+        await using var prompter = await Prompter.Create(client, true, ct);
+        await client.Synchronization.ResumeAsync(new ResumeRequest
         {
             Prompter = prompter.Identifier,
             Selection = new Selection
@@ -247,6 +262,59 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             },
         }, cancellationToken: ct);
 
+        var session = await GetSyncSession(client, identifier, ct);
+        await UpdateState(client, ct);
+        return session;
+    }
+
+    public async Task TerminateSyncSession(string identifier, CancellationToken ct = default)
+    {
+        using var _ = await _lock.LockAsync(ct);
+        var client = await EnsureDaemon(ct);
+
+        // Terminating sessions doesn't require prompting as seen in the mutagen CLI.
+        await using var prompter = await Prompter.Create(client, true, ct);
+
+        await client.Synchronization.TerminateAsync(new SynchronizationTerminateRequest
+        {
+            Prompter = prompter.Identifier,
+            Selection = new Selection
+            {
+                Specifications = { identifier },
+            },
+        }, cancellationToken: ct);
+
+        await UpdateState(client, ct);
+    }
+
+    private async Task UpdateLoop(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(2), ct); // 2s matches macOS app
+            try
+            {
+                // We use a zero timeout here to avoid waiting. If another
+                // operation is holding the lock, it will update the state once
+                // it completes anyway.
+                var locker = await _lock.LockAsync(TimeSpan.Zero, ct);
+                if (locker == null) continue;
+                using (locker)
+                {
+                    if (_mutagenClient == null) continue;
+                    await UpdateState(_mutagenClient, ct);
+                }
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+    }
+
+    private static async Task<SyncSessionModel> GetSyncSession(MutagenClient client, string identifier,
+        CancellationToken ct)
+    {
         var listRes = await client.Synchronization.ListAsync(new ListRequest
         {
             Selection = new Selection
@@ -261,144 +329,141 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         return new SyncSessionModel(listRes.SessionStates[0]);
     }
 
-    public async Task<IEnumerable<SyncSessionModel>> ListSyncSessions(CancellationToken ct = default)
+    private void ReplaceState(SyncSessionControllerStateModel state)
     {
-        // reads of _sessionCount are atomic, so don't bother locking for this quick check.
-        switch (_sessionCount)
-        {
-            case < 0:
-                throw new InvalidOperationException("Controller must be Initialized first");
-            case 0:
-                // If we already know there are no sessions, don't start up the daemon
-                // again.
-                return [];
-        }
-
-        var client = await EnsureDaemon(ct);
-        var res = await client.Synchronization.ListAsync(new ListRequest
-        {
-            Selection = new Selection { All = true },
-        }, cancellationToken: ct);
-
-        if (res == null) return [];
-        return res.SessionStates.Select(s => new SyncSessionModel(s));
-
-        // TODO: the daemon should be stopped if there are no sessions.
+        _state = state;
+        // Since the event handlers could block (or call back the
+        // SyncSessionController and deadlock), we run these in a new task.
+        var stateChanged = StateChanged;
+        if (stateChanged == null) return;
+        Task.Run(() => stateChanged.Invoke(this, state));
     }
 
-    public async Task Initialize(CancellationToken ct = default)
+    /// <summary>
+    ///     Refreshes state and potentially stops the daemon if there are no sessions. The client must not be used after
+    ///     this method is called.
+    ///     Must be called AND awaited with the lock held.
+    /// </summary>
+    private async Task<SyncSessionControllerStateModel> UpdateState(MutagenClient client,
+        CancellationToken ct = default)
     {
-        using (_ = await _lock.LockAsync(ct))
+        ListResponse listResponse;
+        try
         {
-            if (_sessionCount != -1) throw new InvalidOperationException("Initialized more than once");
-            _sessionCount = -2; // in progress
-        }
-
-        var client = await EnsureDaemon(ct);
-        var sessions = await client.Synchronization.ListAsync(new ListRequest
-        {
-            Selection = new Selection { All = true },
-        }, cancellationToken: ct);
-
-        using (_ = await _lock.LockAsync(ct))
-        {
-            _sessionCount = sessions == null ? 0 : sessions.SessionStates.Count;
-            // check first that no other transition is happening
-            if (_sessionCount != 0 || _inProgressTransition != null)
-                return;
-
-            // don't pass the CancellationToken; we're not going to wait for
-            // this Task anyway.
-            var transition = StopDaemon(new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token);
-            _inProgressTransition = transition;
-            _ = transition.ContinueWith(RemoveTransition, CancellationToken.None);
-            // here we don't need to wait for the transition to complete
-            // before returning from Initialize(), since other operations
-            // will wait for the _inProgressTransition to complete before
-            // doing anything.
-        }
-    }
-
-    public async Task TerminateSyncSession(string identifier, CancellationToken ct = default)
-    {
-        if (_sessionCount < 0) throw new InvalidOperationException("Controller must be Initialized first");
-        var client = await EnsureDaemon(ct);
-
-        // Terminating sessions doesn't require prompting as seen in the mutagen CLI.
-        await using var prompter = await CreatePrompter(client, true, ct);
-
-        _ = await client.Synchronization.TerminateAsync(new SynchronizationTerminateRequest
-        {
-            Prompter = prompter.Identifier,
-            Selection = new Selection
+            listResponse = await client.Synchronization.ListAsync(new ListRequest
             {
-                Specifications = { identifier },
-            },
-        }, cancellationToken: ct);
-
-        // here we don't use the Cancellation Token, since we want to decrement and possibly
-        // stop the daemon even if we were cancelled, since we already successfully terminated
-        // the session.
-        using (_ = await _lock.LockAsync(CancellationToken.None))
-        {
-            _sessionCount -= 1;
-            if (_sessionCount == 0)
-                // check first that no other transition is happening
-                if (_inProgressTransition == null)
-                {
-                    var transition = StopDaemon(CancellationToken.None);
-                    _inProgressTransition = transition;
-                    _ = transition.ContinueWith(RemoveTransition, CancellationToken.None);
-                    // here we don't need to wait for the transition to complete
-                    // before returning, since other operations
-                    // will wait for the _inProgressTransition to complete before
-                    // doing anything.
-                }
+                Selection = new Selection { All = true },
+            }, cancellationToken: ct);
+            if (listResponse == null)
+                throw new InvalidOperationException("ListAsync returned null");
         }
-    }
-
-    private async Task<MutagenClient> EnsureDaemon(CancellationToken ct)
-    {
-        while (true)
+        catch (Exception e)
         {
-            ct.ThrowIfCancellationRequested();
-            Task<MutagenClient?> transition;
-            using (_ = await _lock.LockAsync(ct))
+            var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var error = $"Failed to UpdateState: ListAsync: {e}";
+            try
             {
-                if (_disposing) throw new ObjectDisposedException(ToString(), "async disposal underway");
-                if (_mutagenClient != null && _inProgressTransition == null) return _mutagenClient;
-                if (_inProgressTransition != null)
-                {
-                    transition = _inProgressTransition;
-                }
-                else
-                {
-                    // no transition in progress, this implies the _mutagenClient
-                    // must be null, and we are stopped.
-                    _inProgressTransition = StartDaemon(ct);
-                    transition = _inProgressTransition;
-                    _ = transition.ContinueWith(RemoveTransition, ct);
-                }
+                await StopDaemon(cts.Token);
+            }
+            catch (Exception e2)
+            {
+                error = $"Failed to UpdateState: StopDaemon failed after failed ListAsync call: {e2}";
             }
 
-            // wait for the transition without holding the lock.
-            var result = await transition;
-            if (result != null) return result;
+            ReplaceState(new SyncSessionControllerStateModel
+            {
+                Lifecycle = SyncSessionControllerLifecycle.Stopped,
+                DaemonError = error,
+                DaemonLogFilePath = MutagenDaemonLog,
+                SyncSessions = [],
+            });
+            throw;
+        }
+
+        var lifecycle = SyncSessionControllerLifecycle.Running;
+        if (listResponse.SessionStates.Count == 0)
+        {
+            lifecycle = SyncSessionControllerLifecycle.Stopped;
+            try
+            {
+                await StopDaemon(ct);
+            }
+            catch (Exception e)
+            {
+                ReplaceState(new SyncSessionControllerStateModel
+                {
+                    Lifecycle = SyncSessionControllerLifecycle.Stopped,
+                    DaemonError = $"Failed to stop daemon after no sessions: {e}",
+                    DaemonLogFilePath = MutagenDaemonLog,
+                    SyncSessions = [],
+                });
+                throw new InvalidOperationException("Failed to stop daemon after no sessions", e);
+            }
+        }
+
+        var sessions = listResponse.SessionStates
+            .Select(s => new SyncSessionModel(s))
+            .ToList();
+        sessions.Sort((a, b) => a.CreatedAt < b.CreatedAt ? -1 : 1);
+        var state = new SyncSessionControllerStateModel
+        {
+            Lifecycle = lifecycle,
+            DaemonError = null,
+            DaemonLogFilePath = MutagenDaemonLog,
+            SyncSessions = sessions,
+        };
+        ReplaceState(state);
+        return state;
+    }
+
+    /// <summary>
+    ///     Starts the daemon if it's not running and returns a client to it.
+    ///     Must be called AND awaited with the lock held.
+    /// </summary>
+    private async Task<MutagenClient> EnsureDaemon(CancellationToken ct)
+    {
+        ObjectDisposedException.ThrowIf(_disposing, typeof(MutagenController));
+        if (_mutagenClient != null && _daemonProcess != null)
+            return _mutagenClient;
+
+        try
+        {
+            return await StartDaemon(ct);
+        }
+        catch (Exception e)
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            try
+            {
+                await StopDaemon(cts.Token);
+            }
+            catch
+            {
+                // ignored
+            }
+
+            ReplaceState(new SyncSessionControllerStateModel
+            {
+                Lifecycle = SyncSessionControllerLifecycle.Stopped,
+                DaemonError = $"Failed to start daemon: {e}",
+                DaemonLogFilePath = MutagenDaemonLog,
+                SyncSessions = [],
+            });
+
+            throw;
         }
     }
 
-    // <summary>
-    // Remove the completed transition from _inProgressTransition
-    // </summary>
-    private void RemoveTransition(Task<MutagenClient?> transition)
+    /// <summary>
+    ///     Starts the daemon and returns a client to it.
+    ///     Must be called AND awaited with the lock held.
+    /// </summary>
+    private async Task<MutagenClient> StartDaemon(CancellationToken ct)
     {
-        using var _ = _lock.Lock();
-        if (_inProgressTransition == transition) _inProgressTransition = null;
-    }
+        // Stop the running daemon
+        if (_daemonProcess != null) await StopDaemon(ct);
 
-    private async Task<MutagenClient?> StartDaemon(CancellationToken ct)
-    {
-        // stop any orphaned daemon
+        // Attempt to stop any orphaned daemon
         try
         {
             var client = new MutagenClient(_mutagenDataDirectory);
@@ -422,10 +487,7 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             ct.ThrowIfCancellationRequested();
             try
             {
-                using (_ = await _lock.LockAsync(ct))
-                {
-                    StartDaemonProcessLocked();
-                }
+                StartDaemonProcess();
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
@@ -439,34 +501,16 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             break;
         }
 
-        return await WaitForDaemon(ct);
-    }
-
-    private async Task<MutagenClient?> WaitForDaemon(CancellationToken ct)
-    {
+        // Wait for the RPC to be available.
         while (true)
         {
             ct.ThrowIfCancellationRequested();
             try
             {
-                MutagenClient? client;
-                using (_ = await _lock.LockAsync(ct))
-                {
-                    client = _mutagenClient ?? new MutagenClient(_mutagenDataDirectory);
-                }
-
+                var client = new MutagenClient(_mutagenDataDirectory);
                 _ = await client.Daemon.VersionAsync(new VersionRequest(), cancellationToken: ct);
-
-                using (_ = await _lock.LockAsync(ct))
-                {
-                    if (_mutagenClient != null)
-                        // Some concurrent process already wrote a client; unexpected
-                        // since we should be ensuring only one transition is happening
-                        // at a time. Start over with the new client.
-                        continue;
-                    _mutagenClient = client;
-                    return _mutagenClient;
-                }
+                _mutagenClient = client;
+                return client;
             }
             catch (Exception e) when
                 (e is not OperationCanceledException) // TODO: Are there other permanent errors we can detect?
@@ -477,10 +521,14 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         }
     }
 
-    private void StartDaemonProcessLocked()
+    /// <summary>
+    ///     Starts the daemon process.
+    ///     Must be called AND awaited with the lock held.
+    /// </summary>
+    private void StartDaemonProcess()
     {
         if (_daemonProcess != null)
-            throw new InvalidOperationException("startDaemonLock called when daemonProcess already present");
+            throw new InvalidOperationException("StartDaemonProcess called when _daemonProcess already present");
 
         // create the log file first, so ensure we have permissions
         Directory.CreateDirectory(_mutagenDataDirectory);
@@ -499,33 +547,32 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         _daemonProcess.StartInfo.RedirectStandardError = true;
         // TODO: log exited process
         // _daemonProcess.Exited += ...
-        _daemonProcess.Start();
+        if (!_daemonProcess.Start())
+            throw new InvalidOperationException("Failed to start mutagen daemon process, Start returned false");
 
         var writer = new LogWriter(_daemonProcess.StandardError, logStream);
         Task.Run(() => { _ = writer.Run(); });
         _logWriter = writer;
     }
 
-    private async Task<MutagenClient?> StopDaemon(CancellationToken ct)
+    /// <summary>
+    ///     Stops the daemon process.
+    ///     Must be called AND awaited with the lock held.
+    /// </summary>
+    private async Task StopDaemon(CancellationToken ct)
     {
-        Process? process;
-        MutagenClient? client;
-        LogWriter? writer;
-        using (_ = await _lock.LockAsync(ct))
-        {
-            process = _daemonProcess;
-            client = _mutagenClient;
-            writer = _logWriter;
-            _daemonProcess = null;
-            _mutagenClient = null;
-            _logWriter = null;
-        }
+        var process = _daemonProcess;
+        var client = _mutagenClient;
+        var writer = _logWriter;
+        _daemonProcess = null;
+        _mutagenClient = null;
+        _logWriter = null;
 
         try
         {
             if (client == null)
             {
-                if (process == null) return null;
+                if (process == null) return;
                 process.Kill(true);
             }
             else
@@ -536,12 +583,12 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
                 }
                 catch
                 {
-                    if (process == null) return null;
+                    if (process == null) return;
                     process.Kill(true);
                 }
             }
 
-            if (process == null) return null;
+            if (process == null) return;
             var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(5));
             await process.WaitForExitAsync(cts.Token);
@@ -552,41 +599,6 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             process?.Dispose();
             writer?.Dispose();
         }
-
-        return null;
-    }
-
-    private static async Task<Prompter> CreatePrompter(MutagenClient client, bool allowPrompts = false,
-        CancellationToken ct = default)
-    {
-        var dup = client.Prompting.Host(cancellationToken: ct);
-        if (dup == null) throw new InvalidOperationException("Prompting.Host returned null");
-
-        try
-        {
-            // Write first request.
-            await dup.RequestStream.WriteAsync(new HostRequest
-            {
-                AllowPrompts = allowPrompts,
-            }, ct);
-
-            // Read initial response.
-            if (!await dup.ResponseStream.MoveNext(ct))
-                throw new InvalidOperationException("Prompting.Host response stream ended early");
-            var response = dup.ResponseStream.Current;
-            if (response == null)
-                throw new InvalidOperationException("Prompting.Host response stream returned null");
-            if (string.IsNullOrEmpty(response.Identifier))
-                throw new InvalidOperationException("Prompting.Host response stream returned empty identifier");
-
-            return new Prompter(response.Identifier, dup, ct);
-        }
-        catch
-        {
-            await dup.RequestStream.CompleteAsync();
-            dup.Dispose();
-            throw;
-        }
     }
 
     private class Prompter : IAsyncDisposable
@@ -596,7 +608,7 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
         private readonly Task _handleRequestsTask;
         public string Identifier { get; }
 
-        public Prompter(string identifier, AsyncDuplexStreamingCall<HostRequest, HostResponse> dup,
+        private Prompter(string identifier, AsyncDuplexStreamingCall<HostRequest, HostResponse> dup,
             CancellationToken ct)
         {
             Identifier = identifier;
@@ -620,6 +632,39 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
 
             _cts.Dispose();
             GC.SuppressFinalize(this);
+        }
+
+        public static async Task<Prompter> Create(MutagenClient client, bool allowPrompts = false,
+            CancellationToken ct = default)
+        {
+            var dup = client.Prompting.Host(cancellationToken: ct);
+            if (dup == null) throw new InvalidOperationException("Prompting.Host returned null");
+
+            try
+            {
+                // Write first request.
+                await dup.RequestStream.WriteAsync(new HostRequest
+                {
+                    AllowPrompts = allowPrompts,
+                }, ct);
+
+                // Read initial response.
+                if (!await dup.ResponseStream.MoveNext(ct))
+                    throw new InvalidOperationException("Prompting.Host response stream ended early");
+                var response = dup.ResponseStream.Current;
+                if (response == null)
+                    throw new InvalidOperationException("Prompting.Host response stream returned null");
+                if (string.IsNullOrEmpty(response.Identifier))
+                    throw new InvalidOperationException("Prompting.Host response stream returned empty identifier");
+
+                return new Prompter(response.Identifier, dup, ct);
+            }
+            catch
+            {
+                await dup.RequestStream.CompleteAsync();
+                dup.Dispose();
+                throw;
+            }
         }
 
         private async Task HandleRequests(CancellationToken ct)
@@ -657,31 +702,30 @@ public sealed class MutagenController : ISyncSessionController, IAsyncDisposable
             }
         }
     }
-}
 
-public class LogWriter(StreamReader reader, StreamWriter writer) : IDisposable
-{
-    public void Dispose()
+    private class LogWriter(StreamReader reader, StreamWriter writer) : IDisposable
     {
-        reader.Dispose();
-        writer.Dispose();
-        GC.SuppressFinalize(this);
-    }
+        public void Dispose()
+        {
+            reader.Dispose();
+            writer.Dispose();
+            GC.SuppressFinalize(this);
+        }
 
-    public async Task Run()
-    {
-        try
+        public async Task Run()
         {
-            string? line;
-            while ((line = await reader.ReadLineAsync()) != null) await writer.WriteLineAsync(line);
-        }
-        catch
-        {
-            // TODO: Log?
-        }
-        finally
-        {
-            Dispose();
+            try
+            {
+                while (await reader.ReadLineAsync() is { } line) await writer.WriteLineAsync(line);
+            }
+            catch
+            {
+                // TODO: Log?
+            }
+            finally
+            {
+                Dispose();
+            }
         }
     }
 }

--- a/App/Services/RpcController.cs
+++ b/App/Services/RpcController.cs
@@ -96,8 +96,8 @@ public class RpcController : IRpcController
         {
             state.RpcLifecycle = RpcLifecycle.Connecting;
             state.VpnLifecycle = VpnLifecycle.Stopped;
-            state.Workspaces.Clear();
-            state.Agents.Clear();
+            state.Workspaces = [];
+            state.Agents = [];
         });
 
         if (_speaker != null)
@@ -127,8 +127,8 @@ public class RpcController : IRpcController
             {
                 state.RpcLifecycle = RpcLifecycle.Disconnected;
                 state.VpnLifecycle = VpnLifecycle.Unknown;
-                state.Workspaces.Clear();
-                state.Agents.Clear();
+                state.Workspaces = [];
+                state.Agents = [];
             });
             throw new RpcOperationException("Failed to reconnect to the RPC server", e);
         }
@@ -137,8 +137,8 @@ public class RpcController : IRpcController
         {
             state.RpcLifecycle = RpcLifecycle.Connected;
             state.VpnLifecycle = VpnLifecycle.Unknown;
-            state.Workspaces.Clear();
-            state.Agents.Clear();
+            state.Workspaces = [];
+            state.Agents = [];
         });
 
         var statusReply = await _speaker.SendRequestAwaitReply(new ClientMessage
@@ -276,10 +276,8 @@ public class RpcController : IRpcController
                 Status.Types.Lifecycle.Stopped => VpnLifecycle.Stopped,
                 _ => VpnLifecycle.Stopped,
             };
-            state.Workspaces.Clear();
-            state.Workspaces.AddRange(status.PeerUpdate.UpsertedWorkspaces);
-            state.Agents.Clear();
-            state.Agents.AddRange(status.PeerUpdate.UpsertedAgents);
+            state.Workspaces = status.PeerUpdate.UpsertedWorkspaces;
+            state.Agents = status.PeerUpdate.UpsertedAgents;
         });
     }
 

--- a/App/ViewModels/FileSyncListViewModel.cs
+++ b/App/ViewModels/FileSyncListViewModel.cs
@@ -248,23 +248,19 @@ public partial class FileSyncListViewModel : ObservableObject
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         try
         {
-            var alphaUri = new UriBuilder
-            {
-                Scheme = "file",
-                Host = "",
-                Path = NewSessionLocalPath,
-            }.Uri;
-            var betaUri = new UriBuilder
-            {
-                Scheme = "ssh",
-                Host = NewSessionRemoteHost,
-                Path = NewSessionRemotePath,
-            }.Uri;
-
             await _syncSessionController.CreateSyncSession(new CreateSyncSessionRequest
             {
-                Alpha = alphaUri,
-                Beta = betaUri,
+                Alpha = new CreateSyncSessionRequestEndpoint
+                {
+                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Path = NewSessionLocalPath,
+                },
+                Beta = new CreateSyncSessionRequestEndpoint
+                {
+                    Protocol = CreateSyncSessionRequestEndpointProtocol.Ssh,
+                    Host = NewSessionRemoteHost,
+                    Path = NewSessionRemotePath,
+                },
             }, cts.Token);
 
             ClearNewForm();

--- a/App/ViewModels/FileSyncListViewModel.cs
+++ b/App/ViewModels/FileSyncListViewModel.cs
@@ -250,14 +250,14 @@ public partial class FileSyncListViewModel : ObservableObject
         {
             await _syncSessionController.CreateSyncSession(new CreateSyncSessionRequest
             {
-                Alpha = new CreateSyncSessionRequestEndpoint
+                Alpha = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                     Path = NewSessionLocalPath,
                 },
-                Beta = new CreateSyncSessionRequestEndpoint
+                Beta = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Ssh,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Ssh,
                     Host = NewSessionRemoteHost,
                     Path = NewSessionRemotePath,
                 },

--- a/App/ViewModels/FileSyncListViewModel.cs
+++ b/App/ViewModels/FileSyncListViewModel.cs
@@ -31,10 +31,12 @@ public partial class FileSyncListViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(ShowSessions))]
     public partial string? UnavailableMessage { get; set; } = null;
 
+    // Initially we use the current cached state, the loading screen is only
+    // shown when the user clicks "Reload" on the error screen.
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowLoading))]
     [NotifyPropertyChangedFor(nameof(ShowSessions))]
-    public partial bool Loading { get; set; } = true;
+    public partial bool Loading { get; set; } = false;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowLoading))]
@@ -100,11 +102,13 @@ public partial class FileSyncListViewModel : ObservableObject
 
         _rpcController.StateChanged += RpcControllerStateChanged;
         _credentialManager.CredentialsChanged += CredentialManagerCredentialsChanged;
+        _syncSessionController.StateChanged += SyncSessionStateChanged;
 
         var rpcModel = _rpcController.GetState();
         var credentialModel = _credentialManager.GetCachedCredentials();
         MaybeSetUnavailableMessage(rpcModel, credentialModel);
-        if (UnavailableMessage == null) ReloadSessions();
+        var syncSessionState = _syncSessionController.GetState();
+        UpdateSyncSessionState(syncSessionState);
     }
 
     private void RpcControllerStateChanged(object? sender, RpcModel rpcModel)
@@ -135,6 +139,19 @@ public partial class FileSyncListViewModel : ObservableObject
         MaybeSetUnavailableMessage(rpcModel, credentialModel);
     }
 
+    private void SyncSessionStateChanged(object? sender, SyncSessionControllerStateModel syncSessionState)
+    {
+        // Ensure we're on the UI thread.
+        if (_dispatcherQueue == null) return;
+        if (!_dispatcherQueue.HasThreadAccess)
+        {
+            _dispatcherQueue.TryEnqueue(() => SyncSessionStateChanged(sender, syncSessionState));
+            return;
+        }
+
+        UpdateSyncSessionState(syncSessionState);
+    }
+
     private void MaybeSetUnavailableMessage(RpcModel rpcModel, CredentialModel credentialModel)
     {
         var oldMessage = UnavailableMessage;
@@ -158,6 +175,12 @@ public partial class FileSyncListViewModel : ObservableObject
         }
     }
 
+    private void UpdateSyncSessionState(SyncSessionControllerStateModel syncSessionState)
+    {
+        Error = syncSessionState.DaemonError;
+        Sessions = syncSessionState.SyncSessions.Select(s => new SyncSessionViewModel(this, s)).ToList();
+    }
+
     private void ClearNewForm()
     {
         CreatingNewSession = false;
@@ -172,23 +195,24 @@ public partial class FileSyncListViewModel : ObservableObject
         Loading = true;
         Error = null;
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-        _syncSessionController.ListSyncSessions(cts.Token).ContinueWith(HandleList, CancellationToken.None);
+        _syncSessionController.RefreshState(cts.Token).ContinueWith(HandleRefresh, CancellationToken.None);
     }
 
-    private void HandleList(Task<IEnumerable<SyncSessionModel>> t)
+    private void HandleRefresh(Task<SyncSessionControllerStateModel> t)
     {
         // Ensure we're on the UI thread.
         if (_dispatcherQueue == null) return;
         if (!_dispatcherQueue.HasThreadAccess)
         {
-            _dispatcherQueue.TryEnqueue(() => HandleList(t));
+            _dispatcherQueue.TryEnqueue(() => HandleRefresh(t));
             return;
         }
 
         if (t.IsCompletedSuccessfully)
         {
-            Sessions = t.Result.Select(s => new SyncSessionViewModel(this, s)).ToList();
+            Sessions = t.Result.SyncSessions.Select(s => new SyncSessionViewModel(this, s)).ToList();
             Loading = false;
+            Error = t.Result.DaemonError;
             return;
         }
 
@@ -248,6 +272,7 @@ public partial class FileSyncListViewModel : ObservableObject
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
         try
         {
+            // The controller will send us a state changed event.
             await _syncSessionController.CreateSyncSession(new CreateSyncSessionRequest
             {
                 Alpha = new CreateSyncSessionRequest.Endpoint
@@ -264,7 +289,6 @@ public partial class FileSyncListViewModel : ObservableObject
             }, cts.Token);
 
             ClearNewForm();
-            ReloadSessions();
         }
         catch (Exception e)
         {
@@ -295,6 +319,7 @@ public partial class FileSyncListViewModel : ObservableObject
             if (Sessions.FirstOrDefault(s => s.Model.Identifier == identifier) is not { } session)
                 throw new InvalidOperationException("Session not found");
 
+            // The controller will send us a state changed event.
             if (session.Model.Paused)
             {
                 actionString = "resume";
@@ -305,8 +330,6 @@ public partial class FileSyncListViewModel : ObservableObject
                 actionString = "pause";
                 await _syncSessionController.PauseSyncSession(session.Model.Identifier, cts.Token);
             }
-
-            ReloadSessions();
         }
         catch (Exception e)
         {
@@ -349,9 +372,8 @@ public partial class FileSyncListViewModel : ObservableObject
             if (res is not ContentDialogResult.Primary)
                 return;
 
+            // The controller will send us a state changed event.
             await _syncSessionController.TerminateSyncSession(session.Model.Identifier, cts.Token);
-
-            ReloadSessions();
         }
         catch (Exception e)
         {

--- a/App/ViewModels/SyncSessionViewModel.cs
+++ b/App/ViewModels/SyncSessionViewModel.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using Coder.Desktop.App.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Coder.Desktop.App.ViewModels;
 
@@ -29,5 +31,39 @@ public partial class SyncSessionViewModel : ObservableObject
     public async Task TerminateSession()
     {
         await Parent.TerminateSession(Model.Identifier);
+    }
+
+    // Check the comments in FileSyncListMainPage.xaml to see why this tooltip
+    // stuff is necessary.
+    private void SetToolTip(FrameworkElement element, string text)
+    {
+        // Get current tooltip and compare the text. Setting the tooltip with
+        // the same text causes it to dismiss itself.
+        var currentToolTip = ToolTipService.GetToolTip(element) as ToolTip;
+        if (currentToolTip?.Content as string == text) return;
+
+        ToolTipService.SetToolTip(element, new ToolTip { Content = text });
+    }
+
+    public void OnStatusTextLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement element) return;
+        SetToolTip(element, Model.StatusDetails);
+    }
+
+    public void OnStatusTextDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        SetToolTip(sender, Model.StatusDetails);
+    }
+
+    public void OnSizeTextLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement element) return;
+        SetToolTip(element, Model.SizeDetails);
+    }
+
+    public void OnSizeTextDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        SetToolTip(sender, Model.SizeDetails);
     }
 }

--- a/App/ViewModels/SyncSessionViewModel.cs
+++ b/App/ViewModels/SyncSessionViewModel.cs
@@ -1,0 +1,33 @@
+using System.Threading.Tasks;
+using Coder.Desktop.App.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Coder.Desktop.App.ViewModels;
+
+public partial class SyncSessionViewModel : ObservableObject
+{
+    public SyncSessionModel Model { get; }
+
+    private FileSyncListViewModel Parent { get; }
+
+    public string Icon => Model.Paused ? "\uE768" : "\uE769";
+
+    public SyncSessionViewModel(FileSyncListViewModel parent, SyncSessionModel model)
+    {
+        Parent = parent;
+        Model = model;
+    }
+
+    [RelayCommand]
+    public async Task PauseOrResumeSession()
+    {
+        await Parent.PauseOrResumeSession(Model.Identifier);
+    }
+
+    [RelayCommand]
+    public async Task TerminateSession()
+    {
+        await Parent.TerminateSession(Model.Identifier);
+    }
+}

--- a/App/Views/FileSyncListWindow.xaml.cs
+++ b/App/Views/FileSyncListWindow.xaml.cs
@@ -15,7 +15,7 @@ public sealed partial class FileSyncListWindow : WindowEx
         InitializeComponent();
         SystemBackdrop = new DesktopAcrylicBackdrop();
 
-        ViewModel.Initialize(DispatcherQueue);
+        ViewModel.Initialize(this, DispatcherQueue);
         RootFrame.Content = new FileSyncListMainPage(ViewModel, this);
 
         this.CenterOnScreen();

--- a/App/Views/Pages/FileSyncListMainPage.xaml
+++ b/App/Views/Pages/FileSyncListMainPage.xaml
@@ -127,7 +127,8 @@
 
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="viewmodels:SyncSessionViewModel">
-                                <Grid Margin="0,10">
+                                <!-- DataContext is set here so we can listen to DataContextChanged below -->
+                                <Grid Margin="0,10" DataContext="{x:Bind Model, Mode=OneWay}">
                                     <!-- These are (mostly) from the header Grid and should be copied here -->
                                     <Grid.Resources>
                                         <Style TargetType="Border">
@@ -148,14 +149,14 @@
                                             <HyperlinkButton
                                                 Padding="0"
                                                 Margin="0,0,5,0"
-                                                Command="{x:Bind PauseOrResumeSessionCommand, Mode=OneWay}">
+                                                Command="{x:Bind PauseOrResumeSessionCommand}">
 
-                                                <FontIcon Glyph="{x:Bind Icon, Mode=OneWay}" FontSize="15"
+                                                <FontIcon Glyph="{x:Bind Icon}" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </HyperlinkButton>
                                             <HyperlinkButton
                                                 Padding="0"
-                                                Command="{x:Bind TerminateSessionCommand, Mode=OneWay}">
+                                                Command="{x:Bind TerminateSessionCommand}">
 
                                                 <FontIcon Glyph="&#xF140;" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
@@ -208,16 +209,25 @@
                                                     Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </converters:StringToBrushSelector>
                                         </Border.Resources>
+                                        <!--
+                                            We cannot use a direct binding to ToolTipService.ToolTip here because these
+                                            tooltips are populated from computed properties, which seems to cause the
+                                            tooltip to update (and close) even if the text hasn't changed. Since we
+                                            update the sync session state every 5 seconds, this is super annoying.
+                                        -->
                                         <TextBlock
                                             Text="{x:Bind Model.StatusString}"
                                             TextTrimming="CharacterEllipsis"
                                             Foreground="{Binding Source={StaticResource StatusColor}, Path=SelectedObject}"
-                                            ToolTipService.ToolTip="{x:Bind Model.StatusDetails}" />
+                                            Loaded="{x:Bind OnStatusTextLoaded}"
+                                            DataContextChanged="{x:Bind OnStatusTextDataContextChanged}" />
                                     </Border>
                                     <Border Grid.Column="5">
+                                        <!-- Same thing happens here as it's also a computed property -->
                                         <TextBlock
                                             Text="{x:Bind Model.AlphaSize.SizeBytes, Converter={StaticResource FriendlyByteConverter}}"
-                                            ToolTipService.ToolTip="{x:Bind Model.SizeDetails}" />
+                                            Loaded="{x:Bind OnSizeTextLoaded}"
+                                            DataContextChanged="{x:Bind OnSizeTextDataContextChanged}" />
                                     </Border>
                                 </Grid>
                             </DataTemplate>

--- a/App/Views/Pages/FileSyncListMainPage.xaml
+++ b/App/Views/Pages/FileSyncListMainPage.xaml
@@ -6,7 +6,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:models="using:Coder.Desktop.App.Models"
+    xmlns:viewmodels="using:Coder.Desktop.App.ViewModels"
     xmlns:converters="using:Coder.Desktop.App.Converters"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
@@ -126,7 +126,7 @@
                         </ItemsRepeater.Layout>
 
                         <ItemsRepeater.ItemTemplate>
-                            <DataTemplate x:DataType="models:SyncSessionModel">
+                            <DataTemplate x:DataType="viewmodels:SyncSessionViewModel">
                                 <Grid Margin="0,10">
                                     <!-- These are (mostly) from the header Grid and should be copied here -->
                                     <Grid.Resources>
@@ -145,11 +145,18 @@
 
                                     <Border Grid.Column="0" Padding="0" HorizontalAlignment="Right">
                                         <StackPanel Orientation="Horizontal">
-                                            <HyperlinkButton Padding="0" Margin="0,0,5,0">
-                                                <FontIcon Glyph="&#xE769;" FontSize="15"
+                                            <HyperlinkButton
+                                                Padding="0"
+                                                Margin="0,0,5,0"
+                                                Command="{x:Bind PauseOrResumeSessionCommand, Mode=OneWay}">
+
+                                                <FontIcon Glyph="{x:Bind Icon, Mode=OneWay}" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </HyperlinkButton>
-                                            <HyperlinkButton Padding="0">
+                                            <HyperlinkButton
+                                                Padding="0"
+                                                Command="{x:Bind TerminateSessionCommand, Mode=OneWay}">
+
                                                 <FontIcon Glyph="&#xF140;" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </HyperlinkButton>
@@ -157,19 +164,19 @@
                                     </Border>
                                     <Border Grid.Column="1" Padding="10,0,0,0">
                                         <TextBlock
-                                            Text="{x:Bind AlphaPath}"
+                                            Text="{x:Bind Model.AlphaPath}"
                                             TextTrimming="CharacterEllipsis"
                                             IsTextTrimmedChanged="TooltipText_IsTextTrimmedChanged" />
                                     </Border>
                                     <Border Grid.Column="2">
                                         <TextBlock
-                                            Text="{x:Bind BetaName}"
+                                            Text="{x:Bind Model.BetaName}"
                                             TextTrimming="CharacterEllipsis"
                                             IsTextTrimmedChanged="TooltipText_IsTextTrimmedChanged" />
                                     </Border>
                                     <Border Grid.Column="3">
                                         <TextBlock
-                                            Text="{x:Bind BetaPath}"
+                                            Text="{x:Bind Model.BetaPath}"
                                             TextTrimming="CharacterEllipsis"
                                             IsTextTrimmedChanged="TooltipText_IsTextTrimmedChanged" />
                                     </Border>
@@ -177,7 +184,7 @@
                                         <Border.Resources>
                                             <converters:StringToBrushSelector
                                                 x:Key="StatusColor"
-                                                SelectedKey="{x:Bind Path=StatusCategory}">
+                                                SelectedKey="{x:Bind Path=Model.StatusCategory}">
 
                                                 <converters:StringToBrushSelectorItem
                                                     Value="{ThemeResource SystemFillColorCriticalBrush}" />
@@ -202,15 +209,15 @@
                                             </converters:StringToBrushSelector>
                                         </Border.Resources>
                                         <TextBlock
-                                            Text="{x:Bind StatusString}"
+                                            Text="{x:Bind Model.StatusString}"
                                             TextTrimming="CharacterEllipsis"
                                             Foreground="{Binding Source={StaticResource StatusColor}, Path=SelectedObject}"
-                                            ToolTipService.ToolTip="{x:Bind StatusDetails}" />
+                                            ToolTipService.ToolTip="{x:Bind Model.StatusDetails}" />
                                     </Border>
                                     <Border Grid.Column="5">
                                         <TextBlock
-                                            Text="{x:Bind AlphaSize.SizeBytes, Converter={StaticResource FriendlyByteConverter}}"
-                                            ToolTipService.ToolTip="{x:Bind SizeDetails}" />
+                                            Text="{x:Bind Model.AlphaSize.SizeBytes, Converter={StaticResource FriendlyByteConverter}}"
+                                            ToolTipService.ToolTip="{x:Bind Model.SizeDetails}" />
                                     </Border>
                                 </Grid>
                             </DataTemplate>
@@ -315,7 +322,7 @@
                             <TextBox
                                 VerticalAlignment="Stretch"
                                 HorizontalAlignment="Stretch"
-                                Text="{x:Bind ViewModel.NewSessionRemoteName, Mode=TwoWay}" />
+                                Text="{x:Bind ViewModel.NewSessionRemoteHost, Mode=TwoWay}" />
                         </Border>
                         <Border Grid.Column="3">
                             <TextBox

--- a/App/Views/Pages/TrayWindowMainPage.xaml
+++ b/App/Views/Pages/TrayWindowMainPage.xaml
@@ -218,17 +218,6 @@
         <controls:HorizontalRule />
 
         <HyperlinkButton
-            NavigateUri="{x:Bind ViewModel.DashboardUrl, Mode=OneWay}"
-            Margin="-12,0"
-            HorizontalAlignment="Stretch"
-            HorizontalContentAlignment="Left">
-
-            <TextBlock Text="Create workspace" Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
-        </HyperlinkButton>
-
-        <controls:HorizontalRule />
-
-        <HyperlinkButton
             Command="{x:Bind ViewModel.ShowFileSyncListWindowCommand, Mode=OneWay}"
             Margin="-12,0"
             HorizontalAlignment="Stretch"
@@ -236,6 +225,17 @@
 
             <!-- TODO: status icon if there is a problem -->
             <TextBlock Text="File sync" Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
+        </HyperlinkButton>
+
+        <controls:HorizontalRule />
+
+        <HyperlinkButton
+            NavigateUri="{x:Bind ViewModel.DashboardUrl, Mode=OneWay}"
+            Margin="-12,0"
+            HorizontalAlignment="Stretch"
+            HorizontalContentAlignment="Left">
+
+            <TextBlock Text="Create workspace" Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
         </HyperlinkButton>
 
         <controls:HorizontalRule />

--- a/MutagenSdk/NamedPipesConnectionFactory.cs
+++ b/MutagenSdk/NamedPipesConnectionFactory.cs
@@ -24,7 +24,9 @@ public class NamedPipesConnectionFactory
 
         try
         {
-            await client.ConnectAsync(cancellationToken);
+            // Set an upper limit of 2.5 seconds. MutagenSdk consumers can
+            // retry if necessary.
+            await client.ConnectAsync(2500, cancellationToken);
             return client;
         }
         catch

--- a/MutagenSdk/Proto/service/prompting/prompting.proto
+++ b/MutagenSdk/Proto/service/prompting/prompting.proto
@@ -1,0 +1,81 @@
+/*
+ * This file was taken from
+ * https://github.com/mutagen-io/mutagen/tree/v0.18.1/pkg/service/prompting/prompting.proto
+ *
+ * MIT License
+ *
+ * Copyright (c) 2016-present Docker, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+syntax = "proto3";
+
+package prompting;
+option csharp_namespace = "Coder.Desktop.MutagenSdk.Proto.Service.Prompting";
+
+option go_package = "github.com/mutagen-io/mutagen/pkg/service/prompting";
+
+// HostRequest encodes either an initial request to perform prompt hosting or a
+// follow-up response to a message or prompt.
+message HostRequest {
+    // AllowPrompts indicates whether or not the hoster will allow prompts. If
+    // not, it will only receive message requests. This field may only be set on
+    // the initial request.
+    bool allowPrompts = 1;
+    // Response is the prompt response, if any. On the initial request, this
+    // must be an empty string. When responding to a prompt, it may be any
+    // value. When responding to a message, it must be an empty string.
+    string response = 2;
+}
+
+// HostResponse encodes either an initial response to perform prompt hosting or
+// a follow-up request for messaging or prompting.
+message HostResponse {
+    // Identifier is the prompter identifier. It is only set in the initial
+    // response sent after the initial request.
+    string identifier = 1;
+    // IsPrompt indicates if the response is requesting a prompt (as opposed to
+    // simple message display).
+    bool isPrompt = 2;
+    // Message is the message associated with the prompt or message.
+    string message = 3;
+}
+
+// PromptRequest encodes a request for prompting by a specific prompter.
+message PromptRequest {
+    // Prompter is the prompter identifier.
+    string prompter = 1;
+    // Prompt is the prompt to present.
+    string prompt = 2;
+}
+
+// PromptResponse encodes the response from a prompter.
+message PromptResponse {
+    // Response is the response returned by the prompter.
+    string response = 1;
+}
+
+// Prompting allows clients to host and request prompting.
+service Prompting {
+    // Host allows clients to perform prompt hosting.
+    rpc Host(stream HostRequest) returns (stream HostResponse) {}
+    // Prompt performs prompting using a specific prompter.
+    rpc Prompt(PromptRequest) returns (PromptResponse) {}
+}

--- a/MutagenSdk/Update-Proto.ps1
+++ b/MutagenSdk/Update-Proto.ps1
@@ -9,8 +9,9 @@ $ErrorActionPreference = "Stop"
 $repo = "mutagen-io/mutagen"
 $protoPrefix = "pkg"
 $entryFiles = @(
-    "service/synchronization/synchronization.proto",
-    "service/daemon/daemon.proto"
+    "service/daemon/daemon.proto",
+    "service/prompting/prompting.proto",
+    "service/synchronization/synchronization.proto"
 )
 
 $outputNamespace = "Coder.Desktop.MutagenSdk.Proto"

--- a/Tests.App/Services/MutagenControllerTest.cs
+++ b/Tests.App/Services/MutagenControllerTest.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Coder.Desktop.App.Models;
 using Coder.Desktop.App.Services;
 using NUnit.Framework.Interfaces;
 
@@ -94,10 +95,22 @@ public class MutagenControllerTest
         var betaDirectory = _tempDirectory.CreateSubdirectory("beta");
 
         await using var controller = new MutagenController(_mutagenBinaryPath, dataDirectory);
-        await controller.Initialize(ct);
 
-        var sessions = (await controller.ListSyncSessions(ct)).ToList();
-        Assert.That(sessions, Is.Empty);
+        // Initial state before calling RefreshState.
+        var state = controller.GetState();
+        Assert.That(state.Lifecycle, Is.EqualTo(SyncSessionControllerLifecycle.Uninitialized));
+        Assert.That(state.DaemonError, Is.Null);
+        Assert.That(state.DaemonLogFilePath, Is.EqualTo(Path.Combine(dataDirectory, "daemon.log")));
+        Assert.That(state.SyncSessions, Is.Empty);
+
+        state = await controller.RefreshState(ct);
+        Assert.That(state.Lifecycle, Is.EqualTo(SyncSessionControllerLifecycle.Stopped));
+        Assert.That(state.DaemonError, Is.Null);
+        Assert.That(state.DaemonLogFilePath, Is.EqualTo(Path.Combine(dataDirectory, "daemon.log")));
+        Assert.That(state.SyncSessions, Is.Empty);
+
+        // Ensure the daemon is stopped because all sessions are terminated.
+        await AssertDaemonStopped(dataDirectory, ct);
 
         var session1 = await controller.CreateSyncSession(new CreateSyncSessionRequest
         {
@@ -113,9 +126,9 @@ public class MutagenControllerTest
             },
         }, ct);
 
-        sessions = (await controller.ListSyncSessions(ct)).ToList();
-        Assert.That(sessions, Has.Count.EqualTo(1));
-        Assert.That(sessions[0].Identifier, Is.EqualTo(session1.Identifier));
+        state = controller.GetState();
+        Assert.That(state.SyncSessions, Has.Count.EqualTo(1));
+        Assert.That(state.SyncSessions[0].Identifier, Is.EqualTo(session1.Identifier));
 
         var session2 = await controller.CreateSyncSession(new CreateSyncSessionRequest
         {
@@ -131,10 +144,10 @@ public class MutagenControllerTest
             },
         }, ct);
 
-        sessions = (await controller.ListSyncSessions(ct)).ToList();
-        Assert.That(sessions, Has.Count.EqualTo(2));
-        Assert.That(sessions.Any(s => s.Identifier == session1.Identifier));
-        Assert.That(sessions.Any(s => s.Identifier == session2.Identifier));
+        state = controller.GetState();
+        Assert.That(state.SyncSessions, Has.Count.EqualTo(2));
+        Assert.That(state.SyncSessions.Any(s => s.Identifier == session1.Identifier));
+        Assert.That(state.SyncSessions.Any(s => s.Identifier == session2.Identifier));
 
         // Write a file to alpha.
         var alphaFile = Path.Combine(alphaDirectory.FullName, "file.txt");
@@ -161,11 +174,14 @@ public class MutagenControllerTest
         await controller.TerminateSyncSession(session1.Identifier, ct);
         await controller.TerminateSyncSession(session2.Identifier, ct);
 
-        // Ensure the daemon is stopped.
+        // Ensure the daemon is stopped because all sessions are terminated.
         await AssertDaemonStopped(dataDirectory, ct);
 
-        sessions = (await controller.ListSyncSessions(ct)).ToList();
-        Assert.That(sessions, Is.Empty);
+        state = controller.GetState();
+        Assert.That(state.Lifecycle, Is.EqualTo(SyncSessionControllerLifecycle.Stopped));
+        Assert.That(state.DaemonError, Is.Null);
+        Assert.That(state.DaemonLogFilePath, Is.EqualTo(Path.Combine(dataDirectory, "daemon.log")));
+        Assert.That(state.SyncSessions, Is.Empty);
     }
 
     [Test(Description = "Shut down daemon when no sessions")]
@@ -175,7 +191,7 @@ public class MutagenControllerTest
         // NUnit runs each test in a temporary directory
         var dataDirectory = _tempDirectory.FullName;
         await using var controller = new MutagenController(_mutagenBinaryPath, dataDirectory);
-        await controller.Initialize(ct);
+        await controller.RefreshState(ct);
 
         // log file tells us the daemon was started.
         var logPath = Path.Combine(dataDirectory, "daemon.log");
@@ -196,7 +212,7 @@ public class MutagenControllerTest
 
         await using (var controller = new MutagenController(_mutagenBinaryPath, dataDirectory))
         {
-            await controller.Initialize(ct);
+            await controller.RefreshState(ct);
             await controller.CreateSyncSession(new CreateSyncSessionRequest
             {
                 Alpha = new CreateSyncSessionRequest.Endpoint
@@ -236,7 +252,7 @@ public class MutagenControllerTest
         try
         {
             controller1 = new MutagenController(_mutagenBinaryPath, dataDirectory);
-            await controller1.Initialize(ct);
+            await controller1.RefreshState(ct);
             await controller1.CreateSyncSession(new CreateSyncSessionRequest
             {
                 Alpha = new CreateSyncSessionRequest.Endpoint
@@ -252,7 +268,7 @@ public class MutagenControllerTest
             }, ct);
 
             controller2 = new MutagenController(_mutagenBinaryPath, dataDirectory);
-            await controller2.Initialize(ct);
+            await controller2.RefreshState(ct);
         }
         finally
         {

--- a/Tests.App/Services/MutagenControllerTest.cs
+++ b/Tests.App/Services/MutagenControllerTest.cs
@@ -101,14 +101,14 @@ public class MutagenControllerTest
 
         var session1 = await controller.CreateSyncSession(new CreateSyncSessionRequest
         {
-            Alpha = new CreateSyncSessionRequestEndpoint
+            Alpha = new CreateSyncSessionRequest.Endpoint
             {
-                Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                 Path = alphaDirectory.FullName,
             },
-            Beta = new CreateSyncSessionRequestEndpoint
+            Beta = new CreateSyncSessionRequest.Endpoint
             {
-                Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                 Path = betaDirectory.FullName,
             },
         }, ct);
@@ -119,14 +119,14 @@ public class MutagenControllerTest
 
         var session2 = await controller.CreateSyncSession(new CreateSyncSessionRequest
         {
-            Alpha = new CreateSyncSessionRequestEndpoint
+            Alpha = new CreateSyncSessionRequest.Endpoint
             {
-                Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                 Path = alphaDirectory.FullName,
             },
-            Beta = new CreateSyncSessionRequestEndpoint
+            Beta = new CreateSyncSessionRequest.Endpoint
             {
-                Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                 Path = betaDirectory.FullName,
             },
         }, ct);
@@ -199,14 +199,14 @@ public class MutagenControllerTest
             await controller.Initialize(ct);
             await controller.CreateSyncSession(new CreateSyncSessionRequest
             {
-                Alpha = new CreateSyncSessionRequestEndpoint
+                Alpha = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                     Path = alphaDirectory.FullName,
                 },
-                Beta = new CreateSyncSessionRequestEndpoint
+                Beta = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                     Path = betaDirectory.FullName,
                 },
             }, ct);
@@ -239,14 +239,14 @@ public class MutagenControllerTest
             await controller1.Initialize(ct);
             await controller1.CreateSyncSession(new CreateSyncSessionRequest
             {
-                Alpha = new CreateSyncSessionRequestEndpoint
+                Alpha = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                     Path = alphaDirectory.FullName,
                 },
-                Beta = new CreateSyncSessionRequestEndpoint
+                Beta = new CreateSyncSessionRequest.Endpoint
                 {
-                    Protocol = CreateSyncSessionRequestEndpointProtocol.Local,
+                    Protocol = CreateSyncSessionRequest.Endpoint.ProtocolKind.Local,
                     Path = betaDirectory.FullName,
                 },
             }, ct);


### PR DESCRIPTION
- Adds `PauseSyncSession` and `ResumeSyncSession`
- Adds `SyncSessionViewModel` that wraps `SyncSessionModel` and adds view methods (as you cannot access the parent context if you're in a `ItemsRepeater` apparently)
- Wires up Initialize, List, Pause, Resume, Terminate and Create in the file sync UI

## TODO:
- Prevent the app from loading until mutagen finishes initializing (either successfully or not) (in a different PR)
- Add reinitialization logic to mutagen controller (in a different PR)

Closes #26 
Closes #28 
Closes #29 