### PR TITLE
chore: rework mutagen controller, add polling

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -120,7 +120,7 @@ public partial class App : Application
         // Initialize file sync.
         var syncSessionCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var syncSessionController = _services.GetRequiredService<ISyncSessionController>();
-        _ = syncSessionController.Initialize(syncSessionCts.Token).ContinueWith(t =>
+        _ = syncSessionController.RefreshState(syncSessionCts.Token).ContinueWith(t =>
         {
             // TODO: log
 #if DEBUG

--- a/App/Models/RpcModel.cs
+++ b/App/Models/RpcModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using Coder.Desktop.Vpn.Proto;
 
 namespace Coder.Desktop.App.Models;
@@ -26,9 +25,9 @@ public class RpcModel
 
     public VpnLifecycle VpnLifecycle { get; set; } = VpnLifecycle.Unknown;
 
-    public List<Workspace> Workspaces { get; set; } = [];
+    public IReadOnlyList<Workspace> Workspaces { get; set; } = [];
 
-    public List<Agent> Agents { get; set; } = [];
+    public IReadOnlyList<Agent> Agents { get; set; } = [];
 
     public RpcModel Clone()
     {
@@ -36,8 +35,8 @@ public class RpcModel
         {
             RpcLifecycle = RpcLifecycle,
             VpnLifecycle = VpnLifecycle,
-            Workspaces = Workspaces.ToList(),
-            Agents = Agents.ToList(),
+            Workspaces = Workspaces,
+            Agents = Agents,
         };
     }
 }

--- a/App/Models/SyncSessionControllerStateModel.cs
+++ b/App/Models/SyncSessionControllerStateModel.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace Coder.Desktop.App.Models;
+
+public enum SyncSessionControllerLifecycle
+{
+    // Uninitialized means that the daemon has not been started yet. This can
+    // be resolved by calling RefreshState (or any other RPC method
+    // successfully).
+    Uninitialized,
+
+    // Stopped means that the daemon is not running. This could be because:
+    // - It was never started (pre-Initialize)
+    // - It was stopped due to no sync sessions (post-Initialize, post-operation)
+    // - The last start attempt failed (DaemonError will be set)
+    // - The last daemon process crashed (DaemonError will be set)
+    Stopped,
+
+    // Running is the normal state where the daemon is running and managing
+    // sync sessions. This is only set after a successful start (including
+    // being able to connect to the daemon).
+    Running,
+}
+
+public class SyncSessionControllerStateModel
+{
+    public SyncSessionControllerLifecycle Lifecycle { get; init; } = SyncSessionControllerLifecycle.Stopped;
+
+    /// <summary>
+    ///     May be set when Lifecycle is Stopped to signify that the daemon failed
+    ///     to start or unexpectedly crashed.
+    /// </summary>
+    public string? DaemonError { get; init; }
+
+    public required string DaemonLogFilePath { get; init; }
+
+    /// <summary>
+    ///     This contains the last known state of all sync sessions. Sync sessions
+    ///     are periodically refreshed if the daemon is running. This list is
+    ///     sorted by creation time.
+    /// </summary>
+    public IReadOnlyList<SyncSessionModel> SyncSessions { get; init; } = [];
+}

--- a/App/Models/SyncSessionModel.cs
+++ b/App/Models/SyncSessionModel.cs
@@ -206,6 +206,7 @@ public class SyncSessionModel
 {
     public readonly string Identifier;
     public readonly string Name;
+    public readonly DateTime CreatedAt;
 
     public readonly string AlphaName;
     public readonly string AlphaPath;
@@ -232,7 +233,7 @@ public class SyncSessionModel
         get
         {
             var str = $"{StatusString} ({StatusCategory})\n\n{StatusDescription}";
-            foreach (var err in Errors) str += $"\n\nError: {err}";
+            foreach (var err in Errors) str += $"\n\n{err}";
             foreach (var conflict in Conflicts) str += $"\n\n{conflict.Description()}";
             if (OmittedConflicts > 0) str += $"\n\n{OmittedConflicts:N0} conflicts omitted";
             return str;
@@ -253,6 +254,7 @@ public class SyncSessionModel
     {
         Identifier = state.Session.Identifier;
         Name = state.Session.Name;
+        CreatedAt = state.Session.CreationTime.ToDateTime();
 
         (AlphaName, AlphaPath) = NameAndPathFromUrl(state.Session.Alpha);
         (BetaName, BetaPath) = NameAndPathFromUrl(state.Session.Beta);

--- a/App/Services/MutagenController.cs
+++ b/App/Services/MutagenController.cs
@@ -291,7 +291,7 @@ public sealed class MutagenController : ISyncSessionController
     {
         while (!ct.IsCancellationRequested)
         {
-            await Task.Delay(TimeSpan.FromSeconds(5), ct);
+            await Task.Delay(TimeSpan.FromSeconds(2), ct); // 2s matches macOS app
             try
             {
                 // We use a zero timeout here to avoid waiting. If another

--- a/App/Services/MutagenController.cs
+++ b/App/Services/MutagenController.cs
@@ -158,7 +158,16 @@ public sealed class MutagenController : ISyncSessionController
         _disposing = true;
 
         await _stateUpdateCts.CancelAsync();
-        if (_stateUpdateTask != null) await _stateUpdateTask;
+        if (_stateUpdateTask != null)
+            try
+            {
+                await _stateUpdateTask;
+            }
+            catch
+            {
+                // ignored
+            }
+
         _stateUpdateCts.Dispose();
 
         using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));

--- a/App/Services/RpcController.cs
+++ b/App/Services/RpcController.cs
@@ -96,8 +96,8 @@ public class RpcController : IRpcController
         {
             state.RpcLifecycle = RpcLifecycle.Connecting;
             state.VpnLifecycle = VpnLifecycle.Stopped;
-            state.Workspaces.Clear();
-            state.Agents.Clear();
+            state.Workspaces = [];
+            state.Agents = [];
         });
 
         if (_speaker != null)
@@ -127,8 +127,8 @@ public class RpcController : IRpcController
             {
                 state.RpcLifecycle = RpcLifecycle.Disconnected;
                 state.VpnLifecycle = VpnLifecycle.Unknown;
-                state.Workspaces.Clear();
-                state.Agents.Clear();
+                state.Workspaces = [];
+                state.Agents = [];
             });
             throw new RpcOperationException("Failed to reconnect to the RPC server", e);
         }
@@ -137,8 +137,8 @@ public class RpcController : IRpcController
         {
             state.RpcLifecycle = RpcLifecycle.Connected;
             state.VpnLifecycle = VpnLifecycle.Unknown;
-            state.Workspaces.Clear();
-            state.Agents.Clear();
+            state.Workspaces = [];
+            state.Agents = [];
         });
 
         var statusReply = await _speaker.SendRequestAwaitReply(new ClientMessage
@@ -276,10 +276,8 @@ public class RpcController : IRpcController
                 Status.Types.Lifecycle.Stopped => VpnLifecycle.Stopped,
                 _ => VpnLifecycle.Stopped,
             };
-            state.Workspaces.Clear();
-            state.Workspaces.AddRange(status.PeerUpdate.UpsertedWorkspaces);
-            state.Agents.Clear();
-            state.Agents.AddRange(status.PeerUpdate.UpsertedAgents);
+            state.Workspaces = status.PeerUpdate.UpsertedWorkspaces;
+            state.Agents = status.PeerUpdate.UpsertedAgents;
         });
     }
 

--- a/App/ViewModels/SyncSessionViewModel.cs
+++ b/App/ViewModels/SyncSessionViewModel.cs
@@ -2,6 +2,8 @@ using System.Threading.Tasks;
 using Coder.Desktop.App.Models;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 
 namespace Coder.Desktop.App.ViewModels;
 
@@ -29,5 +31,39 @@ public partial class SyncSessionViewModel : ObservableObject
     public async Task TerminateSession()
     {
         await Parent.TerminateSession(Model.Identifier);
+    }
+
+    // Check the comments in FileSyncListMainPage.xaml to see why this tooltip
+    // stuff is necessary.
+    private void SetToolTip(FrameworkElement element, string text)
+    {
+        // Get current tooltip and compare the text. Setting the tooltip with
+        // the same text causes it to dismiss itself.
+        var currentToolTip = ToolTipService.GetToolTip(element) as ToolTip;
+        if (currentToolTip?.Content as string == text) return;
+
+        ToolTipService.SetToolTip(element, new ToolTip { Content = text });
+    }
+
+    public void OnStatusTextLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement element) return;
+        SetToolTip(element, Model.StatusDetails);
+    }
+
+    public void OnStatusTextDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        SetToolTip(sender, Model.StatusDetails);
+    }
+
+    public void OnSizeTextLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not FrameworkElement element) return;
+        SetToolTip(element, Model.SizeDetails);
+    }
+
+    public void OnSizeTextDataContextChanged(FrameworkElement sender, DataContextChangedEventArgs args)
+    {
+        SetToolTip(sender, Model.SizeDetails);
     }
 }

--- a/App/Views/Pages/FileSyncListMainPage.xaml
+++ b/App/Views/Pages/FileSyncListMainPage.xaml
@@ -127,7 +127,8 @@
 
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="viewmodels:SyncSessionViewModel">
-                                <Grid Margin="0,10">
+                                <!-- DataContext is set here so we can listen to DataContextChanged below -->
+                                <Grid Margin="0,10" DataContext="{x:Bind Model, Mode=OneWay}">
                                     <!-- These are (mostly) from the header Grid and should be copied here -->
                                     <Grid.Resources>
                                         <Style TargetType="Border">
@@ -148,14 +149,14 @@
                                             <HyperlinkButton
                                                 Padding="0"
                                                 Margin="0,0,5,0"
-                                                Command="{x:Bind PauseOrResumeSessionCommand, Mode=OneWay}">
+                                                Command="{x:Bind PauseOrResumeSessionCommand}">
 
-                                                <FontIcon Glyph="{x:Bind Icon, Mode=OneWay}" FontSize="15"
+                                                <FontIcon Glyph="{x:Bind Icon}" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </HyperlinkButton>
                                             <HyperlinkButton
                                                 Padding="0"
-                                                Command="{x:Bind TerminateSessionCommand, Mode=OneWay}">
+                                                Command="{x:Bind TerminateSessionCommand}">
 
                                                 <FontIcon Glyph="&#xF140;" FontSize="15"
                                                           Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
@@ -208,16 +209,25 @@
                                                     Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
                                             </converters:StringToBrushSelector>
                                         </Border.Resources>
+                                        <!--
+                                            We cannot use a direct binding to ToolTipService.ToolTip here because these
+                                            tooltips are populated from computed properties, which seems to cause the
+                                            tooltip to update (and close) even if the text hasn't changed. Since we
+                                            update the sync session state every 5 seconds, this is super annoying.
+                                        -->
                                         <TextBlock
                                             Text="{x:Bind Model.StatusString}"
                                             TextTrimming="CharacterEllipsis"
                                             Foreground="{Binding Source={StaticResource StatusColor}, Path=SelectedObject}"
-                                            ToolTipService.ToolTip="{x:Bind Model.StatusDetails}" />
+                                            Loaded="{x:Bind OnStatusTextLoaded}"
+                                            DataContextChanged="{x:Bind OnStatusTextDataContextChanged}" />
                                     </Border>
                                     <Border Grid.Column="5">
+                                        <!-- Same thing happens here as it's also a computed property -->
                                         <TextBlock
                                             Text="{x:Bind Model.AlphaSize.SizeBytes, Converter={StaticResource FriendlyByteConverter}}"
-                                            ToolTipService.ToolTip="{x:Bind Model.SizeDetails}" />
+                                            Loaded="{x:Bind OnSizeTextLoaded}"
+                                            DataContextChanged="{x:Bind OnSizeTextDataContextChanged}" />
                                     </Border>
                                 </Grid>
                             </DataTemplate>

--- a/MutagenSdk/NamedPipesConnectionFactory.cs
+++ b/MutagenSdk/NamedPipesConnectionFactory.cs
@@ -24,7 +24,9 @@ public class NamedPipesConnectionFactory
 
         try
         {
-            await client.ConnectAsync(cancellationToken);
+            // Set an upper limit of 2.5 seconds. MutagenSdk consumers can
+            // retry if necessary.
+            await client.ConnectAsync(2500, cancellationToken);
             return client;
         }
         catch

--- a/Tests.App/Services/MutagenControllerTest.cs
+++ b/Tests.App/Services/MutagenControllerTest.cs
@@ -98,7 +98,7 @@ public class MutagenControllerTest
 
         // Initial state before calling RefreshState.
         var state = controller.GetState();
-        Assert.That(state.Lifecycle, Is.EqualTo(SyncSessionControllerLifecycle.Stopped));
+        Assert.That(state.Lifecycle, Is.EqualTo(SyncSessionControllerLifecycle.Uninitialized));
         Assert.That(state.DaemonError, Is.Null);
         Assert.That(state.DaemonLogFilePath, Is.EqualTo(Path.Combine(dataDirectory, "daemon.log")));
         Assert.That(state.SyncSessions, Is.Empty);


### PR DESCRIPTION
- Use locks during operations for daemon process consistency
- Use a state model for UI rendering
- Use events to signal state changes
- Fix some tooltip problems that arise from polling