### PR TITLE
fix: fix Downloader to dispose tempFile and use synchronous IO 

### DIFF
--- a/Vpn.Service/Downloader.cs
+++ b/Vpn.Service/Downloader.cs
@@ -453,27 +453,26 @@ public class DownloadTask
         if (res.Content.Headers.ContentLength >= 0)
             TotalBytes = (ulong)res.Content.Headers.ContentLength;
 
-        FileStream tempFile;
-        try
-        {
-            tempFile = File.Create(TempDestinationPath, BufferSize,
-                FileOptions.Asynchronous | FileOptions.SequentialScan);
-        }
-        catch (Exception e)
-        {
-            _logger.LogError(e, "Failed to create temporary file '{TempDestinationPath}'", TempDestinationPath);
-            throw;
-        }
-
-        await Download(res, tempFile, ct);
+        await Download(res, ct);
         return;
     }
 
-    private async Task Download(HttpResponseMessage res, FileStream tempFile, CancellationToken ct)
+    private async Task Download(HttpResponseMessage res, CancellationToken ct)
     {
         try
         {
             var sha1 = res.Headers.Contains("ETag") ? SHA1.Create() : null;
+            FileStream tempFile;
+            try
+            {
+                tempFile = File.Create(TempDestinationPath, BufferSize,
+                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Failed to create temporary file '{TempDestinationPath}'", TempDestinationPath);
+                throw;
+            }
             await using (tempFile)
             {
                 var stream = await res.Content.ReadAsStreamAsync(ct);

--- a/Vpn.Service/Downloader.cs
+++ b/Vpn.Service/Downloader.cs
@@ -465,8 +465,7 @@ public class DownloadTask
             FileStream tempFile;
             try
             {
-                tempFile = File.Create(TempDestinationPath, BufferSize,
-                    FileOptions.Asynchronous | FileOptions.SequentialScan);
+                tempFile = File.Create(TempDestinationPath, BufferSize, FileOptions.SequentialScan);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fixes https://github.com/coder/internal/issues/598

There is a possible race where if the cancellation token is expired, `Download()` never gets called and the tempFile is never disposed of (at least until GC). We also switch to synchronous IO so that a pending overlapped write won't block the deletion.

These issues can cause races in our tests when we try to clean up the directory.