### PR TITLE
fix: fix daemon.lock race on mutagen startup

### DIFF
--- a/MutagenSdk/MutagenClient.cs
+++ b/MutagenSdk/MutagenClient.cs
@@ -16,26 +16,6 @@ public class MutagenClient : IDisposable
 
     public MutagenClient(string dataDir)
     {
-        // Check for the lock file first, since it should exist if it's running.
-        var daemonLockFile = Path.Combine(dataDir, "daemon", "daemon.lock");
-        if (!File.Exists(daemonLockFile))
-            throw new FileNotFoundException(
-                "Mutagen daemon lock file not found, did the mutagen daemon start successfully?", daemonLockFile);
-
-        // We should not be able to open the lock file.
-        try
-        {
-            using var _ = File.Open(daemonLockFile, FileMode.Open, FileAccess.Write, FileShare.None);
-            // We throw a FileNotFoundException if we could open the file because
-            // it means the same thing and allows us to return the path nicely.
-            throw new InvalidOperationException(
-                $"Mutagen daemon lock file '{daemonLockFile}' is unlocked, did the mutagen daemon start successfully?");
-        }
-        catch (IOException)
-        {
-            // this is what we expect
-        }
-
         // Read the IPC named pipe address from the sock file.
         var daemonSockFile = Path.Combine(dataDir, "daemon", "daemon.sock");
         if (!File.Exists(daemonSockFile))


### PR DESCRIPTION
I found the source of the issue where mutagen would fail to acquire the lock on `daemon.lock` at startup.

The MutagenClient attempts to lock the `daemon.lock` file while it is starting, so that it can fail fast if the daemon is not running.

While well meaning, this creates a race condition because as soon as we start the daemon process we create a MutagenClient so that we can talk to the daemon over its API. The MutagenClient might be holding the lock or have the lockfile open at the exact moment the daemon itself attempts to acquire and lock the file. The daemon immediately exits in that case and doesn't retry locking the file.

I've just removed the preflight checks on the `daemon.lock`, since we don't want Coder Desktop to ever mess with that file (outside of tests).