### PR TITLE
chore: make hostname suffix mutable in views

### DIFF
--- a/App/Views/Pages/TrayWindowMainPage.xaml
+++ b/App/Views/Pages/TrayWindowMainPage.xaml
@@ -169,9 +169,9 @@
                                         TextTrimming="CharacterEllipsis"
                                         TextWrapping="NoWrap">
 
-                                        <Run Text="{x:Bind Hostname, Mode=OneWay}"
+                                        <Run Text="{x:Bind ViewableHostname, Mode=OneWay}"
                                              Foreground="{ThemeResource DefaultTextForegroundThemeBrush}" />
-                                        <Run Text="{x:Bind HostnameSuffix, Mode=OneWay}"
+                                        <Run Text="{x:Bind ViewableHostnameSuffix, Mode=OneWay}"
                                              Foreground="{ThemeResource SystemControlForegroundBaseMediumBrush}" />
                                     </TextBlock>
 

--- a/App/Views/Pages/TrayWindowMainPage.xaml.cs
+++ b/App/Views/Pages/TrayWindowMainPage.xaml.cs
@@ -18,9 +18,9 @@ public sealed partial class TrayWindowMainPage : Page
     }
 
     // HACK: using XAML to populate the text Runs results in an additional
-    // whitespace Run being inserted between the Hostname and the
-    // HostnameSuffix. You might think, "OK let's populate the entire TextBlock
-    // content from code then!", but this results in the ItemsRepeater
+    // whitespace Run being inserted between the ViewableHostname and the
+    // ViewableHostnameSuffix. You might think, "OK let's populate the entire
+    // TextBlock content from code then!", but this results in the ItemsRepeater
     // corrupting it and firing events off to the wrong AgentModel.
     //
     // This is the best solution I came up with that worked.
@@ -28,12 +28,12 @@ public sealed partial class TrayWindowMainPage : Page
     {
         if (sender is not TextBlock textBlock) return;
 
-        var nonEmptyRuns = new List<Run>();
+        var nonWhitespaceRuns = new List<Run>();
         foreach (var inline in textBlock.Inlines)
-            if (inline is Run run && !string.IsNullOrWhiteSpace(run.Text))
-                nonEmptyRuns.Add(run);
+            if (inline is Run run && run.Text != " ")
+                nonWhitespaceRuns.Add(run);
 
         textBlock.Inlines.Clear();
-        foreach (var run in nonEmptyRuns) textBlock.Inlines.Add(run);
+        foreach (var run in nonWhitespaceRuns) textBlock.Inlines.Add(run);
     }
 }


### PR DESCRIPTION
Part 1 of #49

Makes the workspace suffix dynamic in the views. A later PR in this stack will fetch the suffix and apply it to any views if it changes.

If the suffix doesn't match the FQDN provided by the VPN service, we won't gray out anything when we show the name, but if we later get a suffix that matches, it will update.