### PR TITLE
feat: fetch hostname suffix from API

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -72,6 +72,7 @@ public partial class App : Application
             new WindowsCredentialBackend(WindowsCredentialBackend.CoderCredentialsTargetName));
         services.AddSingleton<ICredentialManager, CredentialManager>();
         services.AddSingleton<IRpcController, RpcController>();
+        services.AddSingleton<IHostnameSuffixGetter, HostnameSuffixGetter>();
 
         services.AddOptions<MutagenControllerConfig>()
             .Bind(builder.Configuration.GetSection(MutagenControllerConfigSection));

--- a/App/Models/CredentialModel.cs
+++ b/App/Models/CredentialModel.cs
@@ -1,4 +1,5 @@
 using System;
+using Coder.Desktop.CoderSdk.Coder;
 
 namespace Coder.Desktop.App.Models;
 
@@ -14,7 +15,7 @@ public enum CredentialState
     Valid,
 }
 
-public class CredentialModel
+public class CredentialModel : ICoderApiClientCredentialProvider
 {
     public CredentialState State { get; init; } = CredentialState.Unknown;
 
@@ -31,6 +32,16 @@ public class CredentialModel
             CoderUrl = CoderUrl,
             ApiToken = ApiToken,
             Username = Username,
+        };
+    }
+
+    public CoderApiClientCredential? GetCoderApiClientCredential()
+    {
+        if (State != CredentialState.Valid) return null;
+        return new CoderApiClientCredential
+        {
+            ApiToken = ApiToken!,
+            CoderUrl = CoderUrl!,
         };
     }
 }

--- a/App/Services/HostnameSuffixGetter.cs
+++ b/App/Services/HostnameSuffixGetter.cs
@@ -78,8 +78,7 @@ public class HostnameSuffixGetter : IHostnameSuffixGetter
             _dirty = false;
         }
 
-        var client = _clientFactory.Create(credentials.CoderUrl!.ToString());
-        client.SetSessionToken(credentials.ApiToken!);
+        var client = _clientFactory.Create(credentials);
         using var timeoutSrc = new CancellationTokenSource(TimeSpan.FromSeconds(10));
         var connInfo = await client.GetAgentConnectionInfoGeneric(timeoutSrc.Token);
 

--- a/App/Services/HostnameSuffixGetter.cs
+++ b/App/Services/HostnameSuffixGetter.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Coder.Desktop.App.Models;
+using Coder.Desktop.CoderSdk.Coder;
+using Coder.Desktop.Vpn.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace Coder.Desktop.App.Services;
+
+public interface IHostnameSuffixGetter
+{
+    public event EventHandler<string> SuffixChanged;
+
+    public string GetCachedSuffix();
+}
+
+public class HostnameSuffixGetter : IHostnameSuffixGetter
+{
+    private const string DefaultSuffix = ".coder";
+
+    private readonly ICredentialManager _credentialManager;
+    private readonly ICoderApiClientFactory _clientFactory;
+    private readonly ILogger<HostnameSuffixGetter> _logger;
+
+    // _lock protects all private (non-readonly) values
+    private readonly RaiiSemaphoreSlim _lock = new(1, 1);
+    private string _domainSuffix = DefaultSuffix;
+    private bool _dirty = false;
+    private bool _getInProgress = false;
+    private CredentialModel _credentialModel = new() { State = CredentialState.Invalid };
+
+    public event EventHandler<string>? SuffixChanged;
+
+    public HostnameSuffixGetter(ICredentialManager credentialManager, ICoderApiClientFactory apiClientFactory,
+        ILogger<HostnameSuffixGetter> logger)
+    {
+        _credentialManager = credentialManager;
+        _clientFactory = apiClientFactory;
+        _logger = logger;
+        credentialManager.CredentialsChanged += HandleCredentialsChanged;
+        HandleCredentialsChanged(this, _credentialManager.GetCachedCredentials());
+    }
+
+    ~HostnameSuffixGetter()
+    {
+        _credentialManager.CredentialsChanged -= HandleCredentialsChanged;
+    }
+
+    private void HandleCredentialsChanged(object? sender, CredentialModel credentials)
+    {
+        using var _ = _lock.Lock();
+        _logger.LogDebug("credentials updated with state {state}", credentials.State);
+        _credentialModel = credentials;
+        if (credentials.State != CredentialState.Valid) return;
+
+        _dirty = true;
+        if (!_getInProgress)
+        {
+            _getInProgress = true;
+            Task.Run(Refresh).ContinueWith(MaybeRefreshAgain);
+        }
+    }
+
+    private async Task Refresh()
+    {
+        _logger.LogDebug("refreshing domain suffix");
+        CredentialModel credentials;
+        using (_ = await _lock.LockAsync())
+        {
+            credentials = _credentialModel;
+            if (credentials.State != CredentialState.Valid)
+            {
+                _logger.LogDebug("abandoning refresh because credentials are now invalid");
+                return;
+            }
+
+            _dirty = false;
+        }
+
+        var client = _clientFactory.Create(credentials.CoderUrl!.ToString());
+        client.SetSessionToken(credentials.ApiToken!);
+        using var timeoutSrc = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var connInfo = await client.GetAgentConnectionInfoGeneric(timeoutSrc.Token);
+
+        // older versions of Coder might not set this
+        var suffix = string.IsNullOrEmpty(connInfo.HostnameSuffix)
+            ? DefaultSuffix
+            // and, it doesn't include the leading dot.
+            : "." + connInfo.HostnameSuffix;
+
+        var changed = false;
+        using (_ = await _lock.LockAsync(CancellationToken.None))
+        {
+            if (_domainSuffix != suffix) changed = true;
+            _domainSuffix = suffix;
+        }
+
+        if (changed)
+        {
+            _logger.LogInformation("got new domain suffix '{suffix}'", suffix);
+            // grab a local copy of the EventHandler to avoid TOCTOU race on the `?.` null-check
+            var del = SuffixChanged;
+            del?.Invoke(this, suffix);
+        }
+        else
+        {
+            _logger.LogDebug("domain suffix unchanged '{suffix}'", suffix);
+        }
+    }
+
+    private async Task MaybeRefreshAgain(Task prev)
+    {
+        if (prev.IsFaulted)
+        {
+            _logger.LogError(prev.Exception, "failed to query domain suffix");
+            // back off here before retrying. We're just going to use a fixed, long
+            // delay since this just affects UI stuff; we're not in a huge rush as
+            // long as we eventually get the right value.
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        using var l = await _lock.LockAsync(CancellationToken.None);
+        if ((_dirty || prev.IsFaulted) && _credentialModel.State == CredentialState.Valid)
+        {
+            // we still have valid credentials and we're either dirty or the last Get failed.
+            _logger.LogDebug("retrying domain suffix query");
+            _ = Task.Run(Refresh).ContinueWith(MaybeRefreshAgain);
+            return;
+        }
+
+        // Getting here means either the credentials are not valid or we don't need to
+        // refresh anyway.
+        // The next time we get new, valid credentials, HandleCredentialsChanged will kick off
+        // a new Refresh
+        _getInProgress = false;
+        return;
+    }
+
+    public string GetCachedSuffix()
+    {
+        using var _ = _lock.Lock();
+        return _domainSuffix;
+    }
+}

--- a/CoderSdk/Coder/CoderApiClient.cs
+++ b/CoderSdk/Coder/CoderApiClient.cs
@@ -49,6 +49,7 @@ public partial interface ICoderApiClient
     public void SetSessionToken(string token);
 }
 
+[JsonSerializable(typeof(AgentConnectionInfo))]
 [JsonSerializable(typeof(BuildInfo))]
 [JsonSerializable(typeof(Response))]
 [JsonSerializable(typeof(User))]

--- a/CoderSdk/Coder/WorkspaceAgents.cs
+++ b/CoderSdk/Coder/WorkspaceAgents.cs
@@ -3,6 +3,14 @@ namespace Coder.Desktop.CoderSdk.Coder;
 public partial interface ICoderApiClient
 {
     public Task<WorkspaceAgent> GetWorkspaceAgent(string id, CancellationToken ct = default);
+    public Task<AgentConnectionInfo> GetAgentConnectionInfoGeneric(CancellationToken ct = default);
+}
+
+public class AgentConnectionInfo
+{
+    public string HostnameSuffix { get; set; } = string.Empty;
+    // note that we're leaving out several fields including the DERP Map because
+    // we don't use that information, and it's a complex object to define.
 }
 
 public class WorkspaceAgent
@@ -34,5 +42,10 @@ public partial class CoderApiClient
     public Task<WorkspaceAgent> GetWorkspaceAgent(string id, CancellationToken ct = default)
     {
         return SendRequestNoBodyAsync<WorkspaceAgent>(HttpMethod.Get, "/api/v2/workspaceagents/" + id, ct);
+    }
+
+    public Task<AgentConnectionInfo> GetAgentConnectionInfoGeneric(CancellationToken ct = default)
+    {
+        return SendRequestNoBodyAsync<AgentConnectionInfo>(HttpMethod.Get, "/api/v2/workspaceagents/connection", ct);
     }
 }

--- a/Tests.App/Services/HostnameSuffixGetterTest.cs
+++ b/Tests.App/Services/HostnameSuffixGetterTest.cs
@@ -26,7 +26,8 @@ public class HostnameSuffixGetterTest
         _mCoderApiClientFactory = new Mock<ICoderApiClientFactory>(MockBehavior.Strict);
         _mCredentialManager = new Mock<ICredentialManager>(MockBehavior.Strict);
         _mCoderApiClient = new Mock<ICoderApiClient>(MockBehavior.Strict);
-        _mCoderApiClientFactory.Setup(m => m.Create(coderUrl)).Returns(_mCoderApiClient.Object);
+        _mCoderApiClientFactory.Setup(m => m.Create(It.IsAny<ICoderApiClientCredentialProvider>()))
+            .Returns(_mCoderApiClient.Object);
     }
 
     private Mock<ICoderApiClientFactory> _mCoderApiClientFactory;

--- a/Tests.App/Services/HostnameSuffixGetterTest.cs
+++ b/Tests.App/Services/HostnameSuffixGetterTest.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel.DataAnnotations;
+using Coder.Desktop.App.Models;
+using Coder.Desktop.App.Services;
+using Coder.Desktop.CoderSdk.Coder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Serilog;
+
+namespace Coder.Desktop.Tests.App.Services;
+
+[TestFixture]
+public class HostnameSuffixGetterTest
+{
+    const string coderUrl = "https://coder.test/";
+
+    [SetUp]
+    public void SetupMocks()
+    {
+        Log.Logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.NUnitOutput().CreateLogger();
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddSerilog();
+        _logger = (ILogger<HostnameSuffixGetter>)builder.Build().Services
+            .GetService(typeof(ILogger<HostnameSuffixGetter>))!;
+
+        _mCoderApiClientFactory = new Mock<ICoderApiClientFactory>(MockBehavior.Strict);
+        _mCredentialManager = new Mock<ICredentialManager>(MockBehavior.Strict);
+        _mCoderApiClient = new Mock<ICoderApiClient>(MockBehavior.Strict);
+        _mCoderApiClientFactory.Setup(m => m.Create(coderUrl)).Returns(_mCoderApiClient.Object);
+    }
+
+    private Mock<ICoderApiClientFactory> _mCoderApiClientFactory;
+    private Mock<ICredentialManager> _mCredentialManager;
+    private Mock<ICoderApiClient> _mCoderApiClient;
+    private ILogger<HostnameSuffixGetter> _logger;
+
+    [Test(Description = "Mainline no errors")]
+    [CancelAfter(10_000)]
+    public async Task Mainline(CancellationToken ct)
+    {
+        _mCredentialManager.Setup(m => m.GetCachedCredentials())
+            .Returns(new CredentialModel() { State = CredentialState.Invalid });
+        var hostnameSuffixGetter =
+            new HostnameSuffixGetter(_mCredentialManager.Object, _mCoderApiClientFactory.Object, _logger);
+
+        // initially, we return the default
+        Assert.That(hostnameSuffixGetter.GetCachedSuffix(), Is.EqualTo(".coder"));
+
+        // subscribed to suffix changes
+        var suffixCompletion = new TaskCompletionSource<string>();
+        hostnameSuffixGetter.SuffixChanged += (_, suffix) => suffixCompletion.SetResult(suffix);
+
+        // set the client to return "test" as the suffix
+        _mCoderApiClient.Setup(m => m.SetSessionToken("test-token"));
+        _mCoderApiClient.Setup(m => m.GetAgentConnectionInfoGeneric(It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult(new AgentConnectionInfo() { HostnameSuffix = "test" }));
+
+        _mCredentialManager.Raise(m => m.CredentialsChanged += null, _mCredentialManager.Object, new CredentialModel
+        {
+            State = CredentialState.Valid,
+            CoderUrl = new Uri(coderUrl),
+            ApiToken = "test-token",
+        });
+        var gotSuffix = await TaskOrCancellation(suffixCompletion.Task, ct);
+        Assert.That(gotSuffix, Is.EqualTo(".test"));
+
+        // now, we should return the .test domain going forward
+        Assert.That(hostnameSuffixGetter.GetCachedSuffix(), Is.EqualTo(".test"));
+    }
+
+    [Test(Description = "Retries if error")]
+    [CancelAfter(30_000)]
+    // TODO: make this test not have to actually wait for the retry.
+    public async Task RetryError(CancellationToken ct)
+    {
+        _mCredentialManager.Setup(m => m.GetCachedCredentials())
+            .Returns(new CredentialModel() { State = CredentialState.Invalid });
+        var hostnameSuffixGetter =
+            new HostnameSuffixGetter(_mCredentialManager.Object, _mCoderApiClientFactory.Object, _logger);
+
+        // subscribed to suffix changes
+        var suffixCompletion = new TaskCompletionSource<string>();
+        hostnameSuffixGetter.SuffixChanged += (_, suffix) => suffixCompletion.SetResult(suffix);
+
+        // set the client to fail once, then return successfully
+        _mCoderApiClient.Setup(m => m.SetSessionToken("test-token"));
+        var connectionInfoCompletion = new TaskCompletionSource<AgentConnectionInfo>();
+        _mCoderApiClient.SetupSequence(m => m.GetAgentConnectionInfoGeneric(It.IsAny<CancellationToken>()))
+            .Returns(Task.FromException<AgentConnectionInfo>(new Exception("a bad thing happened")))
+            .Returns(Task.FromResult(new AgentConnectionInfo() { HostnameSuffix = "test" }));
+
+        _mCredentialManager.Raise(m => m.CredentialsChanged += null, _mCredentialManager.Object, new CredentialModel
+        {
+            State = CredentialState.Valid,
+            CoderUrl = new Uri(coderUrl),
+            ApiToken = "test-token",
+        });
+        var gotSuffix = await TaskOrCancellation(suffixCompletion.Task, ct);
+        Assert.That(gotSuffix, Is.EqualTo(".test"));
+
+        // now, we should return the .test domain going forward
+        Assert.That(hostnameSuffixGetter.GetCachedSuffix(), Is.EqualTo(".test"));
+    }
+
+    /// <summary>
+    ///     TaskOrCancellation waits for either the task to complete, or the given token to be canceled.
+    /// </summary>
+    internal static async Task<TResult> TaskOrCancellation<TResult>(Task<TResult> task,
+        CancellationToken cancellationToken)
+    {
+        var cancellationTask = new TaskCompletionSource<TResult>();
+        await using (cancellationToken.Register(() => cancellationTask.TrySetCanceled()))
+        {
+            // Wait for either the task or the cancellation
+            var completedTask = await Task.WhenAny(task, cancellationTask.Task);
+            // Await to propagate exceptions, if any
+            return await completedTask;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #49

Adds support to query the hostname suffix from Coder server, and then propagates any changes to the agent view models.