### PR TITLE
chore: remove verbose curl from Get-WindowsAppSdk.ps1

### DIFF
--- a/scripts/Get-WindowsAppSdk.ps1
+++ b/scripts/Get-WindowsAppSdk.ps1
@@ -10,7 +10,6 @@ function Download-File([string] $url, [string] $outputPath, [string] $etagFile) 
     # We use `curl.exe` here because `Invoke-WebRequest` is notoriously slow.
     & curl.exe `
         --progress-bar `
-        -v `
         --show-error `
         --fail `
         --location `


### PR DESCRIPTION
It's kinda noisy and I think it wasn't intended to be merged.