### PR TITLE
feat: add auto updater

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,9 +158,9 @@ jobs:
         if ($LASTEXITCODE -ne 0) { throw "Failed to generate new appcast" }
 
         # Upload the new appcast and signature to GCS.
-        & gsutil cp $newAppCastPath $env:APPCAST_GCS_URI
+        & gsutil -h "Cache-Control:no-cache,max-age=0" cp $newAppCastPath $env:APPCAST_GCS_URI
         if ($LASTEXITCODE -ne 0) { throw "Failed to upload new appcast" }
-        & gsutil cp $newAppCastSignaturePath $env:APPCAST_SIGNATURE_GCS_URI
+        & gsutil -h "Cache-Control:no-cache,max-age=0" cp $newAppCastSignaturePath $env:APPCAST_SIGNATURE_GCS_URI
         if ($LASTEXITCODE -ne 0) { throw "Failed to upload new appcast signature" }
       env:
         APPCAST_GCS_URI: gs://releases.coder.com/coder-desktop/windows/appcast.xml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,6 +68,9 @@ jobs:
         service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
         token_format: "access_token"
 
+    - name: Install gcloud
+      uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # 2.1.4
+
     - name: Install wix
       shell: pwsh
       run: |
@@ -119,6 +122,43 @@ jobs:
           ${{ steps.release.outputs.ARM64_OUTPUT_PATH }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update appcast
+      if: startsWith(github.ref, 'refs/tags/')
+      shell: pwsh
+        $ErrorActionPreference = "Stop"
+
+        $keyPath = Join-Path $env:TEMP "appcast-key.pem"
+        $key = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:APPCAST_SIGNATURE_KEY_BASE64))
+        Set-Content -Path $keyPath -Value $key
+
+        $oldAppCastPath = Join-Path $env:TEMP "appcast.old.xml"
+        & gsutil cp $env:APPCAST_GCS_URI $oldAppCastPath
+        if ($LASTEXITCODE -ne 0) { throw "Failed to download appcast" }
+
+        $newAppCastPath = Join-Path $env:TEMP "appcast.new.xml"
+        $newAppCastSignaturePath = $newAppCastPath + ".signature"
+        & ./scripts/Update-AppCast.ps1 `
+          -tag "${{ github.ref_name }}" `
+          -version "${{ steps.version.outputs.VERSION }}" `
+          -channel stable `
+          -x64Path "${{ steps.release.outputs.X64_OUTPUT_PATH }}" `
+          -arm64Path "${{ steps.release.outputs.ARM64_OUTPUT_PATH }}" `
+          -keyPath $keyPath `
+          -inputAppCastPath $oldAppCastPath `
+          -outputAppCastPath $newAppCastPath `
+          -outputAppCastSignaturePath $newAppCastSignaturePath
+        if ($LASTEXITCODE -ne 0) { throw "Failed to generate new appcast" }
+
+        & gsutil cp $newAppCastPath $env:APPCAST_GCS_URI
+        if ($LASTEXITCODE -ne 0) { throw "Failed to upload new appcast" }
+        & gsutil cp $newAppCastSignaturePath $env:APPCAST_SIGNATURE_GCS_URI
+        if ($LASTEXITCODE -ne 0) { throw "Failed to upload new appcast signature" }
+      env:
+        APPCAST_GCS_URI: gs://releases.coder.com/coder-desktop/windows/appcast.xml
+        APPCAST_SIGNATURE_GCS_URI: gs://releases.coder.com/coder-desktop/windows/appcast.xml.signature
+        APPCAST_SIGNATURE_KEY_BASE64: ${{ secrets.APPCAST_SIGNATURE_KEY_BASE64 }}
+        GCLOUD_ACCESS_TOKEN: ${{ steps.gcloud_auth.outputs.access_token }}
 
   winget:
     runs-on: depot-windows-latest
@@ -176,7 +216,6 @@ jobs:
           # For wingetcreate. We need a real token since we're pushing a commit
           # to GitHub and then making a PR in a different repo.
           WINGET_GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
-
 
       - name: Comment on PR
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -128,14 +128,21 @@ jobs:
       shell: pwsh
         $ErrorActionPreference = "Stop"
 
+        # The Update-AppCast.ps1 script fetches the release notes from GitHub,
+        # which might take a few seconds to be ready.
+        Start-Sleep -Seconds 10
+
+        # Save the appcast signing key to a temporary file.
         $keyPath = Join-Path $env:TEMP "appcast-key.pem"
         $key = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($env:APPCAST_SIGNATURE_KEY_BASE64))
         Set-Content -Path $keyPath -Value $key
 
+        # Download the old appcast from GCS.
         $oldAppCastPath = Join-Path $env:TEMP "appcast.old.xml"
         & gsutil cp $env:APPCAST_GCS_URI $oldAppCastPath
         if ($LASTEXITCODE -ne 0) { throw "Failed to download appcast" }
 
+        # Generate the new appcast and signature.
         $newAppCastPath = Join-Path $env:TEMP "appcast.new.xml"
         $newAppCastSignaturePath = $newAppCastPath + ".signature"
         & ./scripts/Update-AppCast.ps1 `
@@ -150,6 +157,7 @@ jobs:
           -outputAppCastSignaturePath $newAppCastSignaturePath
         if ($LASTEXITCODE -ne 0) { throw "Failed to generate new appcast" }
 
+        # Upload the new appcast and signature to GCS.
         & gsutil cp $newAppCastPath $env:APPCAST_GCS_URI
         if ($LASTEXITCODE -ne 0) { throw "Failed to upload new appcast" }
         & gsutil cp $newAppCastSignaturePath $env:APPCAST_SIGNATURE_GCS_URI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -177,7 +177,7 @@ jobs:
           # to GitHub and then making a PR in a different repo.
           WINGET_GH_TOKEN: ${{ secrets.CDRCI_GITHUB_TOKEN }}
 
-      
+
       - name: Comment on PR
         run: |
           # wait 30 seconds

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,7 +148,6 @@ jobs:
         $newAppCastSignaturePath = $newAppCastPath + ".signature"
         & ./scripts/Update-AppCast.ps1 `
           -tag "${{ github.ref_name }}" `
-          -version "${{ steps.version.outputs.VERSION }}" `
           -channel stable `
           -x64Path "${{ steps.release.outputs.X64_OUTPUT_PATH }}" `
           -arm64Path "${{ steps.release.outputs.ARM64_OUTPUT_PATH }}" `

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -126,6 +126,7 @@ jobs:
     - name: Update appcast
       if: startsWith(github.ref, 'refs/tags/')
       shell: pwsh
+      run: |
         $ErrorActionPreference = "Stop"
 
         # The Update-AppCast.ps1 script fetches the release notes from GitHub,

--- a/.gitignore
+++ b/.gitignore
@@ -411,3 +411,12 @@ publish
 *.wixmdb
 *.wixprj
 *.wixproj
+
+appcast.xml
+appcast.xml.signature
+*.key
+*.key.*
+*.pem
+*.pem.*
+*.pub
+*.pub.*

--- a/.idea/.idea.Coder.Desktop/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.Coder.Desktop/.idea/projectSettingsUpdater.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="RiderProjectSettingsUpdater">
     <option name="singleClickDiffPreview" value="1" />
+    <option name="unhandledExceptionsIgnoreList" value="1" />
     <option name="vcsConfiguration" value="3" />
   </component>
 </project>

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -34,10 +34,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <None Remove="Views\Pages\UpdaterDownloadProgressMainPage.xaml" />
-    </ItemGroup>
-
-    <ItemGroup>
         <Content Include="coder.ico" />
         <EmbeddedResource Include="Assets\changelog.css" />
         <Manifest Include="$(ApplicationManifest)" />
@@ -89,11 +85,5 @@
         <ProjectReference Include="..\MutagenSdk\MutagenSdk.csproj" />
         <ProjectReference Include="..\Vpn.Proto\Vpn.Proto.csproj" />
         <ProjectReference Include="..\Vpn\Vpn.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Page Update="Views\Pages\UpdaterDownloadProgressMainPage.xaml">
-        <Generator>MSBuild:Compile</Generator>
-      </Page>
     </ItemGroup>
 </Project>

--- a/App/App.csproj
+++ b/App/App.csproj
@@ -19,6 +19,10 @@
         <DefineConstants>DISABLE_XAML_GENERATED_MAIN;DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
 
         <AssemblyName>Coder Desktop</AssemblyName>
+        <AssemblyTitle>Coder Desktop</AssemblyTitle>
+        <Company>Coder Technologies Inc.</Company>
+        <Product>Coder Desktop</Product>
+        <Copyright>© Coder Technologies Inc.</Copyright>
         <ApplicationIcon>coder.ico</ApplicationIcon>
     </PropertyGroup>
 
@@ -30,10 +34,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="coder.ico" />
+      <None Remove="Views\Pages\UpdaterDownloadProgressMainPage.xaml" />
     </ItemGroup>
 
     <ItemGroup>
+        <Content Include="coder.ico" />
+        <EmbeddedResource Include="Assets\changelog.css" />
         <Manifest Include="$(ApplicationManifest)" />
     </ItemGroup>
 
@@ -67,10 +73,15 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.4" />
         <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.250108002" />
+        <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.2" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="WinUIEx" Version="2.5.1" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+        <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -78,5 +89,11 @@
         <ProjectReference Include="..\MutagenSdk\MutagenSdk.csproj" />
         <ProjectReference Include="..\Vpn.Proto\Vpn.Proto.csproj" />
         <ProjectReference Include="..\Vpn\Vpn.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Page Update="Views\Pages\UpdaterDownloadProgressMainPage.xaml">
+        <Generator>MSBuild:Compile</Generator>
+      </Page>
     </ItemGroup>
 </Project>

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -91,6 +91,7 @@ public partial class App : Application
         services.AddSingleton<ICoderApiClientFactory, CoderApiClientFactory>();
         services.AddSingleton<IAgentApiClientFactory, AgentApiClientFactory>();
 
+        services.AddSingleton<IDispatcherQueueManager, AppDispatcherQueueManager>();
         services.AddSingleton<ICredentialBackend>(_ =>
             new WindowsCredentialBackend(WindowsCredentialBackend.CoderCredentialsTargetName));
         services.AddSingleton<ICredentialManager, CredentialManager>();
@@ -291,7 +292,7 @@ public partial class App : Application
     public void HandleNotification(AppNotificationManager? sender, AppNotificationActivatedEventArgs args)
     {
         _logger.LogInformation("handled notification activation: {Argument}", args.Argument);
-        _userNotifier.HandleActivation(args);
+        _userNotifier.HandleNotificationActivation(args.Arguments);
     }
 
     private static void AddDefaultConfig(IConfigurationBuilder builder)

--- a/App/Assets/changelog.css
+++ b/App/Assets/changelog.css
@@ -1,0 +1,1233 @@
+/*
+    This file was taken from:
+    https://github.com/sindresorhus/github-markdown-css/blob/bedb4b771f5fa1ae117df597c79993fd1eb4dff0/github-markdown.css
+
+    Licensed under the MIT license.
+
+    Changes:
+      - Removed @media queries in favor of requiring `[data-theme]` attributes
+*/
+
+.markdown-body {
+  --base-size-4: 0.25rem;
+  --base-size-8: 0.5rem;
+  --base-size-16: 1rem;
+  --base-size-24: 1.5rem;
+  --base-size-40: 2.5rem;
+  --base-text-weight-normal: 400;
+  --base-text-weight-medium: 500;
+  --base-text-weight-semibold: 600;
+  --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
+  --fgColor-accent: Highlight;
+}
+.markdown-body[data-theme="dark"] {
+  /* dark */
+  color-scheme: dark;
+  --focus-outlineColor: #1f6feb;
+  --fgColor-default: #f0f6fc;
+  --fgColor-muted: #9198a1;
+  --fgColor-accent: #4493f8;
+  --fgColor-success: #3fb950;
+  --fgColor-attention: #d29922;
+  --fgColor-danger: #f85149;
+  --fgColor-done: #ab7df8;
+  --bgColor-default: #0d1117;
+  --bgColor-muted: #151b23;
+  --bgColor-neutral-muted: #656c7633;
+  --bgColor-attention-muted: #bb800926;
+  --borderColor-default: #3d444d;
+  --borderColor-muted: #3d444db3;
+  --borderColor-neutral-muted: #3d444db3;
+  --borderColor-accent-emphasis: #1f6feb;
+  --borderColor-success-emphasis: #238636;
+  --borderColor-attention-emphasis: #9e6a03;
+  --borderColor-danger-emphasis: #da3633;
+  --borderColor-done-emphasis: #8957e5;
+  --color-prettylights-syntax-comment: #9198a1;
+  --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
+  --color-prettylights-syntax-entity: #d2a8ff;
+  --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+  --color-prettylights-syntax-entity-tag: #7ee787;
+  --color-prettylights-syntax-keyword: #ff7b72;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-variable: #ffa657;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
+  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-markup-list: #f2cc60;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
+  --color-prettylights-syntax-markup-italic: #f0f6fc;
+  --color-prettylights-syntax-markup-bold: #f0f6fc;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-changed-bg: #5a1e02;
+  --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+  --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-meta-diff-range: #d2a8ff;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+}
+.markdown-body[data-theme="light"] {
+  /* light */
+  color-scheme: light;
+  --focus-outlineColor: #0969da;
+  --fgColor-default: #1f2328;
+  --fgColor-muted: #59636e;
+  --fgColor-accent: #0969da;
+  --fgColor-success: #1a7f37;
+  --fgColor-attention: #9a6700;
+  --fgColor-danger: #d1242f;
+  --fgColor-done: #8250df;
+  --bgColor-default: #ffffff;
+  --bgColor-muted: #f6f8fa;
+  --bgColor-neutral-muted: #818b981f;
+  --bgColor-attention-muted: #fff8c5;
+  --borderColor-default: #d1d9e0;
+  --borderColor-muted: #d1d9e0b3;
+  --borderColor-neutral-muted: #d1d9e0b3;
+  --borderColor-accent-emphasis: #0969da;
+  --borderColor-success-emphasis: #1a7f37;
+  --borderColor-attention-emphasis: #9a6700;
+  --borderColor-danger-emphasis: #cf222e;
+  --borderColor-done-emphasis: #8250df;
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
+  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-variable: #953800;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
+  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-carriage-return-bg: #cf222e;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+}
+
+.markdown-body {
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  margin: 0;
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-default);
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-size: 16px;
+  line-height: 1.5;
+  word-wrap: break-word;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  fill: currentColor;
+  vertical-align: text-bottom;
+}
+
+.markdown-body h1:hover .anchor .octicon-link:before,
+.markdown-body h2:hover .anchor .octicon-link:before,
+.markdown-body h3:hover .anchor .octicon-link:before,
+.markdown-body h4:hover .anchor .octicon-link:before,
+.markdown-body h5:hover .anchor .octicon-link:before,
+.markdown-body h6:hover .anchor .octicon-link:before {
+  width: 16px;
+  height: 16px;
+  content: ' ';
+  display: inline-block;
+  background-color: currentColor;
+  -webkit-mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+  mask-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' version='1.1' aria-hidden='true'><path fill-rule='evenodd' d='M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z'></path></svg>");
+}
+
+.markdown-body details,
+.markdown-body figcaption,
+.markdown-body figure {
+  display: block;
+}
+
+.markdown-body summary {
+  display: list-item;
+}
+
+.markdown-body [hidden] {
+  display: none !important;
+}
+
+.markdown-body a {
+  background-color: transparent;
+  color: var(--fgColor-accent);
+  text-decoration: none;
+}
+
+.markdown-body abbr[title] {
+  border-bottom: none;
+  -webkit-text-decoration: underline dotted;
+  text-decoration: underline dotted;
+}
+
+.markdown-body b,
+.markdown-body strong {
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body dfn {
+  font-style: italic;
+}
+
+.markdown-body h1 {
+  margin: .67em 0;
+  font-weight: var(--base-text-weight-semibold, 600);
+  padding-bottom: .3em;
+  font-size: 2em;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body mark {
+  background-color: var(--bgColor-attention-muted);
+  color: var(--fgColor-default);
+}
+
+.markdown-body small {
+  font-size: 90%;
+}
+
+.markdown-body sub,
+.markdown-body sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+.markdown-body sub {
+  bottom: -0.25em;
+}
+
+.markdown-body sup {
+  top: -0.5em;
+}
+
+.markdown-body img {
+  border-style: none;
+  max-width: 100%;
+  box-sizing: content-box;
+}
+
+.markdown-body code,
+.markdown-body kbd,
+.markdown-body pre,
+.markdown-body samp {
+  font-family: monospace;
+  font-size: 1em;
+}
+
+.markdown-body figure {
+  margin: 1em var(--base-size-40);
+}
+
+.markdown-body hr {
+  box-sizing: content-box;
+  overflow: hidden;
+  background: transparent;
+  border-bottom: 1px solid var(--borderColor-muted);
+  height: .25em;
+  padding: 0;
+  margin: var(--base-size-24) 0;
+  background-color: var(--borderColor-default);
+  border: 0;
+}
+
+.markdown-body input {
+  font: inherit;
+  margin: 0;
+  overflow: visible;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
+  -webkit-appearance: button;
+  appearance: button;
+}
+
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+.markdown-body [type=number]::-webkit-inner-spin-button,
+.markdown-body [type=number]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type=search]::-webkit-search-cancel-button,
+.markdown-body [type=search]::-webkit-search-decoration {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body ::-webkit-input-placeholder {
+  color: inherit;
+  opacity: .54;
+}
+
+.markdown-body ::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  appearance: button;
+  font: inherit;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body ::placeholder {
+  color: var(--fgColor-muted);
+  opacity: 1;
+}
+
+.markdown-body hr::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body hr::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body table {
+  border-spacing: 0;
+  border-collapse: collapse;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow: auto;
+  font-variant: tabular-nums;
+}
+
+.markdown-body td,
+.markdown-body th {
+  padding: 0;
+}
+
+.markdown-body details summary {
+  cursor: pointer;
+}
+
+.markdown-body a:focus,
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
+  outline: solid 1px transparent;
+}
+
+.markdown-body a:focus-visible,
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: -2px;
+  box-shadow: none;
+}
+
+.markdown-body a:not([class]):focus,
+.markdown-body a:not([class]):focus-visible,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
+  outline-offset: 0;
+}
+
+.markdown-body kbd {
+  display: inline-block;
+  padding: var(--base-size-4);
+  font: 11px var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  line-height: 10px;
+  color: var(--fgColor-default);
+  vertical-align: middle;
+  background-color: var(--bgColor-muted);
+  border: solid 1px var(--borderColor-neutral-muted);
+  border-bottom-color: var(--borderColor-neutral-muted);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 var(--borderColor-neutral-muted);
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4,
+.markdown-body h5,
+.markdown-body h6 {
+  margin-top: var(--base-size-24);
+  margin-bottom: var(--base-size-16);
+  font-weight: var(--base-text-weight-semibold, 600);
+  line-height: 1.25;
+}
+
+.markdown-body h2 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  padding-bottom: .3em;
+  font-size: 1.5em;
+  border-bottom: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body h3 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: 1.25em;
+}
+
+.markdown-body h4 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: 1em;
+}
+
+.markdown-body h5 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: .875em;
+}
+
+.markdown-body h6 {
+  font-weight: var(--base-text-weight-semibold, 600);
+  font-size: .85em;
+  color: var(--fgColor-muted);
+}
+
+.markdown-body p {
+  margin-top: 0;
+  margin-bottom: 10px;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: var(--fgColor-muted);
+  border-left: .25em solid var(--borderColor-default);
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
+.markdown-body ol ol,
+.markdown-body ul ol {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ul ul ol,
+.markdown-body ul ol ol,
+.markdown-body ol ul ol,
+.markdown-body ol ol ol {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body dd {
+  margin-left: 0;
+}
+
+.markdown-body tt,
+.markdown-body code,
+.markdown-body samp {
+  font-family: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  font-size: 12px;
+}
+
+.markdown-body pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-family: var(--fontStack-monospace, ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace);
+  font-size: 12px;
+  word-wrap: normal;
+}
+
+.markdown-body .octicon {
+  display: inline-block;
+  overflow: visible !important;
+  vertical-align: text-bottom;
+  fill: currentColor;
+}
+
+.markdown-body input::-webkit-outer-spin-button,
+.markdown-body input::-webkit-inner-spin-button {
+  margin: 0;
+  appearance: none;
+}
+
+.markdown-body .mr-2 {
+  margin-right: var(--base-size-8, 8px) !important;
+}
+
+.markdown-body::before {
+  display: table;
+  content: "";
+}
+
+.markdown-body::after {
+  display: table;
+  clear: both;
+  content: "";
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body .absent {
+  color: var(--fgColor-danger);
+}
+
+.markdown-body .anchor {
+  float: left;
+  padding-right: var(--base-size-4);
+  margin-left: -20px;
+  line-height: 1;
+}
+
+.markdown-body .anchor:focus {
+  outline: none;
+}
+
+.markdown-body p,
+.markdown-body blockquote,
+.markdown-body ul,
+.markdown-body ol,
+.markdown-body dl,
+.markdown-body table,
+.markdown-body pre,
+.markdown-body details {
+  margin-top: 0;
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body h1 .octicon-link,
+.markdown-body h2 .octicon-link,
+.markdown-body h3 .octicon-link,
+.markdown-body h4 .octicon-link,
+.markdown-body h5 .octicon-link,
+.markdown-body h6 .octicon-link {
+  color: var(--fgColor-default);
+  vertical-align: middle;
+  visibility: hidden;
+}
+
+.markdown-body h1:hover .anchor,
+.markdown-body h2:hover .anchor,
+.markdown-body h3:hover .anchor,
+.markdown-body h4:hover .anchor,
+.markdown-body h5:hover .anchor,
+.markdown-body h6:hover .anchor {
+  text-decoration: none;
+}
+
+.markdown-body h1:hover .anchor .octicon-link,
+.markdown-body h2:hover .anchor .octicon-link,
+.markdown-body h3:hover .anchor .octicon-link,
+.markdown-body h4:hover .anchor .octicon-link,
+.markdown-body h5:hover .anchor .octicon-link,
+.markdown-body h6:hover .anchor .octicon-link {
+  visibility: visible;
+}
+
+.markdown-body h1 tt,
+.markdown-body h1 code,
+.markdown-body h2 tt,
+.markdown-body h2 code,
+.markdown-body h3 tt,
+.markdown-body h3 code,
+.markdown-body h4 tt,
+.markdown-body h4 code,
+.markdown-body h5 tt,
+.markdown-body h5 code,
+.markdown-body h6 tt,
+.markdown-body h6 code {
+  padding: 0 .2em;
+  font-size: inherit;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2,
+.markdown-body summary h3,
+.markdown-body summary h4,
+.markdown-body summary h5,
+.markdown-body summary h6 {
+  display: inline-block;
+}
+
+.markdown-body summary h1 .anchor,
+.markdown-body summary h2 .anchor,
+.markdown-body summary h3 .anchor,
+.markdown-body summary h4 .anchor,
+.markdown-body summary h5 .anchor,
+.markdown-body summary h6 .anchor {
+  margin-left: -40px;
+}
+
+.markdown-body summary h1,
+.markdown-body summary h2 {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.markdown-body ul.no-list,
+.markdown-body ol.no-list {
+  padding: 0;
+  list-style-type: none;
+}
+
+.markdown-body ol[type="a s"] {
+  list-style-type: lower-alpha;
+}
+
+.markdown-body ol[type="A s"] {
+  list-style-type: upper-alpha;
+}
+
+.markdown-body ol[type="i s"] {
+  list-style-type: lower-roman;
+}
+
+.markdown-body ol[type="I s"] {
+  list-style-type: upper-roman;
+}
+
+.markdown-body ol[type="1"] {
+  list-style-type: decimal;
+}
+
+.markdown-body div>ol:not([type]) {
+  list-style-type: decimal;
+}
+
+.markdown-body ul ul,
+.markdown-body ul ol,
+.markdown-body ol ol,
+.markdown-body ol ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.markdown-body li>p {
+  margin-top: var(--base-size-16);
+}
+
+.markdown-body li+li {
+  margin-top: .25em;
+}
+
+.markdown-body dl {
+  padding: 0;
+}
+
+.markdown-body dl dt {
+  padding: 0;
+  margin-top: var(--base-size-16);
+  font-size: 1em;
+  font-style: italic;
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body dl dd {
+  padding: 0 var(--base-size-16);
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body table th {
+  font-weight: var(--base-text-weight-semibold, 600);
+}
+
+.markdown-body table th,
+.markdown-body table td {
+  padding: 6px 13px;
+  border: 1px solid var(--borderColor-default);
+}
+
+.markdown-body table td>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table tr {
+  background-color: var(--bgColor-default);
+  border-top: 1px solid var(--borderColor-muted);
+}
+
+.markdown-body table tr:nth-child(2n) {
+  background-color: var(--bgColor-muted);
+}
+
+.markdown-body table img {
+  background-color: transparent;
+}
+
+.markdown-body img[align=right] {
+  padding-left: 20px;
+}
+
+.markdown-body img[align=left] {
+  padding-right: 20px;
+}
+
+.markdown-body .emoji {
+  max-width: none;
+  vertical-align: text-top;
+  background-color: transparent;
+}
+
+.markdown-body span.frame {
+  display: block;
+  overflow: hidden;
+}
+
+.markdown-body span.frame>span {
+  display: block;
+  float: left;
+  width: auto;
+  padding: 7px;
+  margin: 13px 0 0;
+  overflow: hidden;
+  border: 1px solid var(--borderColor-default);
+}
+
+.markdown-body span.frame span img {
+  display: block;
+  float: left;
+}
+
+.markdown-body span.frame span span {
+  display: block;
+  padding: 5px 0 0;
+  clear: both;
+  color: var(--fgColor-default);
+}
+
+.markdown-body span.align-center {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-center>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: center;
+}
+
+.markdown-body span.align-center span img {
+  margin: 0 auto;
+  text-align: center;
+}
+
+.markdown-body span.align-right {
+  display: block;
+  overflow: hidden;
+  clear: both;
+}
+
+.markdown-body span.align-right>span {
+  display: block;
+  margin: 13px 0 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body span.align-right span img {
+  margin: 0;
+  text-align: right;
+}
+
+.markdown-body span.float-left {
+  display: block;
+  float: left;
+  margin-right: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-left span {
+  margin: 13px 0 0;
+}
+
+.markdown-body span.float-right {
+  display: block;
+  float: right;
+  margin-left: 13px;
+  overflow: hidden;
+}
+
+.markdown-body span.float-right>span {
+  display: block;
+  margin: 13px auto 0;
+  overflow: hidden;
+  text-align: right;
+}
+
+.markdown-body code,
+.markdown-body tt {
+  padding: .2em .4em;
+  margin: 0;
+  font-size: 85%;
+  white-space: break-spaces;
+  background-color: var(--bgColor-neutral-muted);
+  border-radius: 6px;
+}
+
+.markdown-body code br,
+.markdown-body tt br {
+  display: none;
+}
+
+.markdown-body del code {
+  text-decoration: inherit;
+}
+
+.markdown-body samp {
+  font-size: 85%;
+}
+
+.markdown-body pre code {
+  font-size: 100%;
+}
+
+.markdown-body pre>code {
+  padding: 0;
+  margin: 0;
+  word-break: normal;
+  white-space: pre;
+  background: transparent;
+  border: 0;
+}
+
+.markdown-body .highlight {
+  margin-bottom: var(--base-size-16);
+}
+
+.markdown-body .highlight pre {
+  margin-bottom: 0;
+  word-break: normal;
+}
+
+.markdown-body .highlight pre,
+.markdown-body pre {
+  padding: var(--base-size-16);
+  overflow: auto;
+  font-size: 85%;
+  line-height: 1.45;
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-muted);
+  border-radius: 6px;
+}
+
+.markdown-body pre code,
+.markdown-body pre tt {
+  display: inline;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  word-wrap: normal;
+  background-color: transparent;
+  border: 0;
+}
+
+.markdown-body .csv-data td,
+.markdown-body .csv-data th {
+  padding: 5px;
+  overflow: hidden;
+  font-size: 12px;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.markdown-body .csv-data .blob-num {
+  padding: 10px var(--base-size-8) 9px;
+  text-align: right;
+  background: var(--bgColor-default);
+  border: 0;
+}
+
+.markdown-body .csv-data tr {
+  border-top: 0;
+}
+
+.markdown-body .csv-data th {
+  font-weight: var(--base-text-weight-semibold, 600);
+  background: var(--bgColor-muted);
+  border-top: 0;
+}
+
+.markdown-body [data-footnote-ref]::before {
+  content: "[";
+}
+
+.markdown-body [data-footnote-ref]::after {
+  content: "]";
+}
+
+.markdown-body .footnotes {
+  font-size: 12px;
+  color: var(--fgColor-muted);
+  border-top: 1px solid var(--borderColor-default);
+}
+
+.markdown-body .footnotes ol {
+  padding-left: var(--base-size-16);
+}
+
+.markdown-body .footnotes ol ul {
+  display: inline-block;
+  padding-left: var(--base-size-16);
+  margin-top: var(--base-size-16);
+}
+
+.markdown-body .footnotes li {
+  position: relative;
+}
+
+.markdown-body .footnotes li:target::before {
+  position: absolute;
+  top: calc(var(--base-size-8)*-1);
+  right: calc(var(--base-size-8)*-1);
+  bottom: calc(var(--base-size-8)*-1);
+  left: calc(var(--base-size-24)*-1);
+  pointer-events: none;
+  content: "";
+  border: 2px solid var(--borderColor-accent-emphasis);
+  border-radius: 6px;
+}
+
+.markdown-body .footnotes li:target {
+  color: var(--fgColor-default);
+}
+
+.markdown-body .footnotes .data-footnote-backref g-emoji {
+  font-family: monospace;
+}
+
+.markdown-body body:has(:modal) {
+  padding-right: var(--dialog-scrollgutter) !important;
+}
+
+.markdown-body .pl-c {
+  color: var(--color-prettylights-syntax-comment);
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-s .pl-v {
+  color: var(--color-prettylights-syntax-constant);
+}
+
+.markdown-body .pl-e,
+.markdown-body .pl-en {
+  color: var(--color-prettylights-syntax-entity);
+}
+
+.markdown-body .pl-smi,
+.markdown-body .pl-s .pl-s1 {
+  color: var(--color-prettylights-syntax-storage-modifier-import);
+}
+
+.markdown-body .pl-ent {
+  color: var(--color-prettylights-syntax-entity-tag);
+}
+
+.markdown-body .pl-k {
+  color: var(--color-prettylights-syntax-keyword);
+}
+
+.markdown-body .pl-s,
+.markdown-body .pl-pds,
+.markdown-body .pl-s .pl-pse .pl-s1,
+.markdown-body .pl-sr,
+.markdown-body .pl-sr .pl-cce,
+.markdown-body .pl-sr .pl-sre,
+.markdown-body .pl-sr .pl-sra {
+  color: var(--color-prettylights-syntax-string);
+}
+
+.markdown-body .pl-v,
+.markdown-body .pl-smw {
+  color: var(--color-prettylights-syntax-variable);
+}
+
+.markdown-body .pl-bu {
+  color: var(--color-prettylights-syntax-brackethighlighter-unmatched);
+}
+
+.markdown-body .pl-ii {
+  color: var(--color-prettylights-syntax-invalid-illegal-text);
+  background-color: var(--color-prettylights-syntax-invalid-illegal-bg);
+}
+
+.markdown-body .pl-c2 {
+  color: var(--color-prettylights-syntax-carriage-return-text);
+  background-color: var(--color-prettylights-syntax-carriage-return-bg);
+}
+
+.markdown-body .pl-sr .pl-cce {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-string-regexp);
+}
+
+.markdown-body .pl-ml {
+  color: var(--color-prettylights-syntax-markup-list);
+}
+
+.markdown-body .pl-mh,
+.markdown-body .pl-mh .pl-en,
+.markdown-body .pl-ms {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-heading);
+}
+
+.markdown-body .pl-mi {
+  font-style: italic;
+  color: var(--color-prettylights-syntax-markup-italic);
+}
+
+.markdown-body .pl-mb {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-markup-bold);
+}
+
+.markdown-body .pl-md {
+  color: var(--color-prettylights-syntax-markup-deleted-text);
+  background-color: var(--color-prettylights-syntax-markup-deleted-bg);
+}
+
+.markdown-body .pl-mi1 {
+  color: var(--color-prettylights-syntax-markup-inserted-text);
+  background-color: var(--color-prettylights-syntax-markup-inserted-bg);
+}
+
+.markdown-body .pl-mc {
+  color: var(--color-prettylights-syntax-markup-changed-text);
+  background-color: var(--color-prettylights-syntax-markup-changed-bg);
+}
+
+.markdown-body .pl-mi2 {
+  color: var(--color-prettylights-syntax-markup-ignored-text);
+  background-color: var(--color-prettylights-syntax-markup-ignored-bg);
+}
+
+.markdown-body .pl-mdr {
+  font-weight: bold;
+  color: var(--color-prettylights-syntax-meta-diff-range);
+}
+
+.markdown-body .pl-ba {
+  color: var(--color-prettylights-syntax-brackethighlighter-angle);
+}
+
+.markdown-body .pl-sg {
+  color: var(--color-prettylights-syntax-sublimelinter-gutter-mark);
+}
+
+.markdown-body .pl-corl {
+  text-decoration: underline;
+  color: var(--color-prettylights-syntax-constant-other-reference-link);
+}
+
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  outline: none;
+  box-shadow: none;
+}
+
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.markdown-body g-emoji {
+  display: inline-block;
+  min-width: 1ch;
+  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 1em;
+  font-style: normal !important;
+  font-weight: var(--base-text-weight-normal, 400);
+  line-height: 1;
+  vertical-align: -0.075em;
+}
+
+.markdown-body g-emoji img {
+  width: 1em;
+  height: 1em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+}
+
+.markdown-body .task-list-item label {
+  font-weight: var(--base-text-weight-normal, 400);
+}
+
+.markdown-body .task-list-item.enabled label {
+  cursor: pointer;
+}
+
+.markdown-body .task-list-item+.task-list-item {
+  margin-top: var(--base-size-4);
+}
+
+.markdown-body .task-list-item .handle {
+  display: none;
+}
+
+.markdown-body .task-list-item-checkbox {
+  margin: 0 .2em .25em -1.4em;
+  vertical-align: middle;
+}
+
+.markdown-body ul:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body ol:dir(rtl) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
+}
+
+.markdown-body .contains-task-list:hover .task-list-item-convert-container,
+.markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
+  display: block;
+  width: auto;
+  height: 24px;
+  overflow: visible;
+  clip: auto;
+}
+
+.markdown-body ::-webkit-calendar-picker-indicator {
+  filter: invert(50%);
+}
+
+.markdown-body .markdown-alert {
+  padding: var(--base-size-8) var(--base-size-16);
+  margin-bottom: var(--base-size-16);
+  color: inherit;
+  border-left: .25em solid var(--borderColor-default);
+}
+
+.markdown-body .markdown-alert>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  font-weight: var(--base-text-weight-medium, 500);
+  align-items: center;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert.markdown-alert-note {
+  border-left-color: var(--borderColor-accent-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
+  color: var(--fgColor-accent);
+}
+
+.markdown-body .markdown-alert.markdown-alert-important {
+  border-left-color: var(--borderColor-done-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
+  color: var(--fgColor-done);
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning {
+  border-left-color: var(--borderColor-attention-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
+  color: var(--fgColor-attention);
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip {
+  border-left-color: var(--borderColor-success-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
+  color: var(--fgColor-success);
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution {
+  border-left-color: var(--borderColor-danger-emphasis);
+}
+
+.markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
+  color: var(--fgColor-danger);
+}
+
+.markdown-body>*:first-child>.heading-element:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body .highlight pre:has(+.zeroclipboard-container) {
+  min-height: 52px;
+}

--- a/App/Assets/changelog.css
+++ b/App/Assets/changelog.css
@@ -6,6 +6,8 @@
 
     Changes:
       - Removed @media queries in favor of requiring `[data-theme]` attributes
+        on the body themselves
+      - Overrides `--bgColor-default` to transparent
 */
 
 .markdown-body {
@@ -19,8 +21,10 @@
   --base-text-weight-semibold: 600;
   --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   --fgColor-accent: Highlight;
+
+  --bgColor-default: transparent !important;
 }
-.markdown-body[data-theme="dark"] {
+body[data-theme="dark"] .markdown-body {
   /* dark */
   color-scheme: dark;
   --focus-outlineColor: #1f6feb;
@@ -74,7 +78,7 @@
   --color-prettylights-syntax-meta-diff-range: #d2a8ff;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
 }
-.markdown-body[data-theme="light"] {
+body[data-theme=""] .markdown-body {
   /* light */
   color-scheme: light;
   --focus-outlineColor: #0969da;

--- a/App/Controls/TrayIcon.xaml
+++ b/App/Controls/TrayIcon.xaml
@@ -32,7 +32,7 @@
                         <XamlUICommand
                             Label="Show Window"
                             Description="Show Window"
-                            Command="{x:Bind OpenCommand, Mode=OneWay}">
+                            Command="{x:Bind OpenCommand}">
 
                             <XamlUICommand.IconSource>
                                 <SymbolIconSource Symbol="OpenPane" />
@@ -53,7 +53,7 @@
                         <XamlUICommand
                             Label="Check for Updates"
                             Description="Check for Updates"
-                            Command="{x:Bind CheckForUpdatesCommand, Mode=OneWay}">
+                            Command="{x:Bind CheckForUpdatesCommand}">
 
                             <XamlUICommand.IconSource>
                                 <SymbolIconSource Symbol="Download" />
@@ -74,7 +74,7 @@
                         <XamlUICommand
                             Label="Exit"
                             Description="Exit"
-                            Command="{x:Bind ExitCommand, Mode=OneWay}">
+                            Command="{x:Bind ExitCommand}">
 
                             <XamlUICommand.IconSource>
                                 <SymbolIconSource Symbol="ClosePane" />

--- a/App/Controls/TrayIcon.xaml
+++ b/App/Controls/TrayIcon.xaml
@@ -32,7 +32,7 @@
                         <XamlUICommand
                             Label="Show Window"
                             Description="Show Window"
-                            Command="{x:Bind OpenCommand}">
+                            Command="{x:Bind OpenCommand, Mode=OneWay}">
 
                             <XamlUICommand.IconSource>
                                 <SymbolIconSource Symbol="OpenPane" />
@@ -51,9 +51,30 @@
                 <MenuFlyoutItem>
                     <MenuFlyoutItem.Command>
                         <XamlUICommand
+                            Label="Check for Updates"
+                            Description="Check for Updates"
+                            Command="{x:Bind CheckForUpdatesCommand, Mode=OneWay}">
+
+                            <XamlUICommand.IconSource>
+                                <SymbolIconSource Symbol="Download" />
+                            </XamlUICommand.IconSource>
+                            <XamlUICommand.KeyboardAccelerators>
+                                <KeyboardAccelerator
+                                    Key="U"
+                                    Modifiers="Control" />
+                            </XamlUICommand.KeyboardAccelerators>
+                        </XamlUICommand>
+                    </MenuFlyoutItem.Command>
+                </MenuFlyoutItem>
+
+                <MenuFlyoutSeparator />
+
+                <MenuFlyoutItem>
+                    <MenuFlyoutItem.Command>
+                        <XamlUICommand
                             Label="Exit"
                             Description="Exit"
-                            Command="{x:Bind ExitCommand}">
+                            Command="{x:Bind ExitCommand, Mode=OneWay}">
 
                             <XamlUICommand.IconSource>
                                 <SymbolIconSource Symbol="ClosePane" />

--- a/App/Controls/TrayIcon.xaml.cs
+++ b/App/Controls/TrayIcon.xaml.cs
@@ -10,6 +10,7 @@ namespace Coder.Desktop.App.Controls;
 
 [DependencyProperty<ICommand>("OpenCommand")]
 [DependencyProperty<ICommand>("ExitCommand")]
+[DependencyProperty<ICommand>("CheckForUpdatesCommand")]
 public sealed partial class TrayIcon : UserControl
 {
     private readonly UISettings _uiSettings = new();

--- a/App/Services/DispatcherQueueManager.cs
+++ b/App/Services/DispatcherQueueManager.cs
@@ -1,29 +1,8 @@
-using System;
 using Microsoft.UI.Dispatching;
-using Microsoft.UI.Xaml;
 
 namespace Coder.Desktop.App.Services;
 
 public interface IDispatcherQueueManager
 {
     public void RunInUiThread(DispatcherQueueHandler action);
-}
-
-public class AppDispatcherQueueManager : IDispatcherQueueManager
-{
-    private static DispatcherQueue? DispatcherQueue =>
-        ((App)Application.Current).TrayWindow?.DispatcherQueue;
-
-    public void RunInUiThread(DispatcherQueueHandler action)
-    {
-        var dispatcherQueue = DispatcherQueue;
-        if (dispatcherQueue is null)
-            throw new InvalidOperationException("DispatcherQueue is not available");
-        if (dispatcherQueue.HasThreadAccess)
-        {
-            action();
-            return;
-        }
-        dispatcherQueue.TryEnqueue(action);
-    }
 }

--- a/App/Services/DispatcherQueueManager.cs
+++ b/App/Services/DispatcherQueueManager.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+
+namespace Coder.Desktop.App.Services;
+
+public interface IDispatcherQueueManager
+{
+    public void RunInUiThread(DispatcherQueueHandler action);
+}
+
+public class AppDispatcherQueueManager : IDispatcherQueueManager
+{
+    private static DispatcherQueue? DispatcherQueue =>
+        ((App)Application.Current).TrayWindow?.DispatcherQueue;
+
+    public void RunInUiThread(DispatcherQueueHandler action)
+    {
+        var dispatcherQueue = DispatcherQueue;
+        if (dispatcherQueue is null)
+            throw new InvalidOperationException("DispatcherQueue is not available");
+        if (dispatcherQueue.HasThreadAccess)
+        {
+            action();
+            return;
+        }
+        dispatcherQueue.TryEnqueue(action);
+    }
+}

--- a/App/Services/UpdateController.cs
+++ b/App/Services/UpdateController.cs
@@ -38,12 +38,10 @@ public static class UpdateChannelExtensions
     }
 }
 
-// TODO: SET THESE TO THE CORRECT SETTINGS
 public class UpdaterConfig
 {
     public bool EnableUpdater { get; set; } = true;
-    //[Required] public string UpdateAppCastUrl { get; set; } = "https://releases.coder.com/coder-desktop/windows/appcast.xml";
-    [Required] public string UpdateAppCastUrl { get; set; } = "http://localhost:8000/appcast.xml";
+    [Required] public string UpdateAppCastUrl { get; set; } = "https://releases.coder.com/coder-desktop/windows/appcast.xml";
     [Required] public string UpdatePublicKeyBase64 { get; set; } = "NNWN4c+3PmMuAf2G1ERLlu0EwhzHfSiUugOt120hrH8=";
     public UpdateChannel? ForcedUpdateChannel { get; set; } = null;
 }

--- a/App/Services/UpdateController.cs
+++ b/App/Services/UpdateController.cs
@@ -92,6 +92,10 @@ public class SparkleUpdateController : IUpdateController
         {
             // TODO: custom Configuration for persistence, could just specify
             //       our own save path with JSONConfiguration TBH
+            // GitHub releases endpoint returns a random UUID as the filename,
+            // so we tell NetSparkle to ignore it and use the last segment of
+            // the URL instead.
+            CheckServerFileName = false,
             LogWriter = new CoderSparkleLogger(logger),
             AppCastHelper = new CoderSparkleAppCastHelper(_config.ForcedUpdateChannel),
             UIFactory = uiFactory,

--- a/App/Services/UpdateController.cs
+++ b/App/Services/UpdateController.cs
@@ -163,6 +163,7 @@ public class SparkleUpdateController : IUpdateController, INotificationHandler
 
     public ValueTask DisposeAsync()
     {
+        _userNotifier.UnregisterHandler(NotificationHandlerName);
         _sparkle?.Dispose();
         return ValueTask.CompletedTask;
     }
@@ -203,9 +204,9 @@ public class CoderSparkleUIFactory(IUserNotifier userNotifier, IUpdaterUpdateAva
 {
     public bool ForceDisableToastMessages;
 
-    bool IUIFactory.HideReleaseNotes { get; set; }
-    bool IUIFactory.HideSkipButton { get; set; }
-    bool IUIFactory.HideRemindMeLaterButton { get; set; }
+    public bool HideReleaseNotes { get; set; }
+    public bool HideSkipButton { get; set; }
+    public bool HideRemindMeLaterButton { get; set; }
 
     // This stuff is ignored as we use our own template in the ViewModel
     // directly:
@@ -215,8 +216,6 @@ public class CoderSparkleUIFactory(IUserNotifier userNotifier, IUpdaterUpdateAva
     public IUpdateAvailable CreateUpdateAvailableWindow(List<AppCastItem> updates, ISignatureVerifier? signatureVerifier,
         string currentVersion = "", string appName = "Coder Desktop", bool isUpdateAlreadyDownloaded = false)
     {
-        IUIFactory factory = this;
-
         var viewModel = updateAvailableViewModelFactory.Create(
             updates,
             signatureVerifier,
@@ -225,11 +224,11 @@ public class CoderSparkleUIFactory(IUserNotifier userNotifier, IUpdaterUpdateAva
             isUpdateAlreadyDownloaded);
 
         var window = new UpdaterUpdateAvailableWindow(viewModel);
-        if (factory.HideReleaseNotes)
+        if (HideReleaseNotes)
             (window as IUpdateAvailable).HideReleaseNotes();
-        if (factory.HideSkipButton)
+        if (HideSkipButton)
             (window as IUpdateAvailable).HideSkipButton();
-        if (factory.HideRemindMeLaterButton)
+        if (HideRemindMeLaterButton)
             (window as IUpdateAvailable).HideRemindMeLaterButton();
 
         return window;

--- a/App/Services/UpdateController.cs
+++ b/App/Services/UpdateController.cs
@@ -101,7 +101,8 @@ public class SparkleUpdateController : IUpdateController
 
         _sparkle.CloseApplicationAsync += SparkleOnCloseApplicationAsync;
 
-        // TODO: user preference for automatic checking
+        // TODO: user preference for automatic checking. Remember to
+        //       StopLoop/StartLoop if it changes.
 #if !DEBUG || true
         _ = _sparkle.StartLoop(true, UpdateCheckInterval);
 #endif

--- a/App/Services/UpdateController.cs
+++ b/App/Services/UpdateController.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Coder.Desktop.App.ViewModels;
+using Coder.Desktop.App.Views;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.UI.Xaml;
+using NetSparkleUpdater;
+using NetSparkleUpdater.AppCastHandlers;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.Interfaces;
+using NetSparkleUpdater.SignatureVerifiers;
+using SparkleLogger = NetSparkleUpdater.Interfaces.ILogger;
+
+namespace Coder.Desktop.App.Services;
+
+// TODO: add preview channel
+public enum UpdateChannel
+{
+    Stable,
+}
+
+public static class UpdateChannelExtensions
+{
+    public static string ChannelName(this UpdateChannel channel)
+    {
+        switch (channel)
+        {
+            case UpdateChannel.Stable:
+                return "stable";
+            default:
+                throw new ArgumentOutOfRangeException(nameof(channel), channel, null);
+        }
+    }
+}
+
+// TODO: SET THESE TO THE CORRECT SETTINGS
+public class UpdaterConfig
+{
+    public bool EnableUpdater { get; set; } = true;
+    //[Required] public string UpdateAppCastUrl { get; set; } = "https://releases.coder.com/coder-desktop/windows/appcast.xml";
+    [Required] public string UpdateAppCastUrl { get; set; } = "http://localhost:8000/appcast.xml";
+    [Required] public string UpdatePublicKeyBase64 { get; set; } = "Uxc0ir6j3GMhkL5D1O/W3lsD4BNk5puwM9hohNfm32k=";
+    public UpdateChannel? ForcedUpdateChannel { get; set; } = null;
+}
+
+public interface IUpdateController : IAsyncDisposable
+{
+    // Must be called from UI thread.
+    public Task CheckForUpdatesNow();
+}
+
+public class SparkleUpdateController : IUpdateController
+{
+    private static readonly TimeSpan UpdateCheckInterval = TimeSpan.FromHours(24);
+
+    private readonly ILogger<SparkleUpdateController> _logger;
+    private readonly UpdaterConfig _config;
+    private readonly IUIFactory _uiFactory;
+
+    private readonly SparkleUpdater? _sparkle;
+
+    public SparkleUpdateController(ILogger<SparkleUpdateController> logger, IOptions<UpdaterConfig> config, IUIFactory uiFactory)
+    {
+        _logger = logger;
+        _config = config.Value;
+        _uiFactory = uiFactory;
+
+        if (!_config.EnableUpdater)
+        {
+            _logger.LogInformation("updater disabled by policy");
+            return;
+        }
+
+        _logger.LogInformation("updater enabled, creating NetSparkle instance");
+
+        // This behavior differs from the macOS version of Coder Desktop, which
+        // does not verify app cast signatures.
+        //
+        // Swift's Sparkle does not support verifying app cast signatures yet,
+        // but we use this functionality on Windows for added security against
+        // malicious release notes.
+        // TODO: REENABLE STRICT CHECKING
+        var checker = new Ed25519Checker(SecurityMode.Unsafe,
+            publicKey: _config.UpdatePublicKeyBase64,
+            readFileBeingVerifiedInChunks: true);
+
+        _sparkle = new SparkleUpdater(_config.UpdateAppCastUrl, checker)
+        {
+            // TODO: custom Configuration for persistence, could just specify
+            //       our own save path with JSONConfiguration TBH
+            LogWriter = new CoderSparkleLogger(logger),
+            AppCastHelper = new CoderSparkleAppCastHelper(logger, _config.ForcedUpdateChannel),
+            UIFactory = uiFactory,
+            UseNotificationToast = uiFactory.CanShowToastMessages(),
+            RelaunchAfterUpdate = true,
+        };
+
+        _sparkle.CloseApplicationAsync += SparkleOnCloseApplicationAsync;
+
+        // TODO: user preference for automatic checking
+#if !DEBUG || true
+        _ = _sparkle.StartLoop(true, UpdateCheckInterval);
+#endif
+    }
+
+    private static async Task SparkleOnCloseApplicationAsync()
+    {
+        await ((App)Application.Current).ExitApplication();
+    }
+
+    public async Task CheckForUpdatesNow()
+    {
+        if (_sparkle == null)
+        {
+            _ = new MessageWindow(
+                "Updates disabled",
+                "The built-in updater is disabled by policy.",
+                "Coder Desktop Updater");
+            return;
+        }
+
+        // NetSparkle will not open the UpdateAvailable window if it can send a
+        // toast, even if the user requested the update. We work around this by
+        // temporarily disabling toasts during this operation.
+        var coderFactory = _uiFactory as CoderSparkleUIFactory;
+        try
+        {
+            if (coderFactory is not null)
+                coderFactory.ForceDisableToasts = true;
+
+            await _sparkle.CheckForUpdatesAtUserRequest(true);
+        }
+        finally
+        {
+            if (coderFactory is not null)
+                coderFactory.ForceDisableToasts = false;
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _sparkle?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}
+
+public class CoderSparkleLogger(ILogger<SparkleUpdateController> logger) : SparkleLogger
+{
+    public void PrintMessage(string message, params object[]? arguments)
+    {
+        logger.LogInformation("[sparkle] " + message, arguments ?? []);
+    }
+}
+
+public class CoderSparkleAppCastHelper : AppCastHelper
+{
+    private readonly UpdateChannel? _forcedChannel;
+
+    public CoderSparkleAppCastHelper(ILogger<SparkleUpdateController> logger, UpdateChannel? forcedChannel) : base()
+    {
+        _forcedChannel = forcedChannel;
+    }
+
+    public override List<AppCastItem> FilterUpdates(List<AppCastItem> items)
+    {
+        items = base.FilterUpdates(items);
+
+        // TODO: factor in user choice too once we have a settings page
+        var channel = _forcedChannel ?? UpdateChannel.Stable;
+        return items.FindAll(i => i.Channel != null && i.Channel == channel.ChannelName());
+    }
+}
+
+// ReSharper disable once InconsistentNaming // the interface name is "UI", not "Ui"
+public class CoderSparkleUIFactory(IUserNotifier userNotifier, IUpdaterUpdateAvailableViewModelFactory updateAvailableViewModelFactory) : IUIFactory
+{
+    public bool ForceDisableToasts;
+
+    bool IUIFactory.HideReleaseNotes { get; set; }
+    bool IUIFactory.HideSkipButton { get; set; }
+    bool IUIFactory.HideRemindMeLaterButton { get; set; }
+
+    // This stuff is ignored as we use our own template in the ViewModel
+    // directly:
+    string? IUIFactory.ReleaseNotesHTMLTemplate { get; set; }
+    string? IUIFactory.AdditionalReleaseNotesHeaderHTML { get; set; }
+
+    public IUpdateAvailable CreateUpdateAvailableWindow(List<AppCastItem> updates, ISignatureVerifier? signatureVerifier,
+        string currentVersion = "", string appName = "Coder Desktop", bool isUpdateAlreadyDownloaded = false)
+    {
+        IUIFactory factory = this;
+
+        var viewModel = updateAvailableViewModelFactory.Create(
+            updates,
+            signatureVerifier,
+            currentVersion,
+            appName,
+            isUpdateAlreadyDownloaded);
+
+        var window = new UpdaterUpdateAvailableWindow(viewModel);
+        if (factory.HideReleaseNotes)
+            (window as IUpdateAvailable).HideReleaseNotes();
+        if (factory.HideSkipButton)
+            (window as IUpdateAvailable).HideSkipButton();
+        if (factory.HideRemindMeLaterButton)
+            (window as IUpdateAvailable).HideRemindMeLaterButton();
+
+        return window;
+    }
+
+    IDownloadProgress IUIFactory.CreateProgressWindow(string downloadTitle, string actionButtonTitleAfterDownload)
+    {
+        var viewModel = new UpdaterDownloadProgressViewModel();
+        return new UpdaterDownloadProgressWindow(viewModel);
+    }
+
+    ICheckingForUpdates IUIFactory.ShowCheckingForUpdates()
+    {
+        return new UpdaterCheckingForUpdatesWindow();
+    }
+
+    void IUIFactory.ShowUnknownInstallerFormatMessage(string downloadFileName)
+    {
+        _ = new MessageWindow("Installer format error",
+            $"The installer format for the downloaded file '{downloadFileName}' is unknown. Please check application logs for more information.",
+            "Coder Desktop Updater");
+    }
+
+    void IUIFactory.ShowVersionIsUpToDate()
+    {
+        _ = new MessageWindow(
+            "No updates available",
+            "Coder Desktop is up to date!",
+            "Coder Desktop Updater");
+    }
+
+    void IUIFactory.ShowVersionIsSkippedByUserRequest()
+    {
+        _ = new MessageWindow(
+            "Update skipped",
+            "You have elected to skip this update.",
+            "Coder Desktop Updater");
+    }
+
+    void IUIFactory.ShowCannotDownloadAppcast(string? appcastUrl)
+    {
+        _ = new MessageWindow("Cannot fetch update information",
+            $"Unable to download the updates manifest from '{appcastUrl}'. Please check your internet connection or firewall settings and try again.",
+            "Coder Desktop Updater");
+    }
+
+    void IUIFactory.ShowDownloadErrorMessage(string message, string? appcastUrl)
+    {
+        _ = new MessageWindow("Download error",
+            $"An error occurred while downloading the update. Please check your internet connection or firewall settings and try again.\n\n{message}",
+            "Coder Desktop Updater");
+    }
+
+    bool IUIFactory.CanShowToastMessages()
+    {
+        return !ForceDisableToasts;
+    }
+
+    void IUIFactory.ShowToast(Action clickHandler)
+    {
+        userNotifier.ShowActionNotification(
+            "Coder Desktop",
+            "Updates are available, click for more information.",
+            clickHandler,
+            CancellationToken.None)
+            .Wait();
+    }
+
+    void IUIFactory.Shutdown()
+    {
+        ((App)Application.Current).ExitApplication().Wait();
+    }
+}

--- a/App/Services/UserNotifier.cs
+++ b/App/Services/UserNotifier.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppNotifications;
 using Microsoft.Windows.AppNotifications.Builder;
 
@@ -9,11 +12,18 @@ namespace Coder.Desktop.App.Services;
 public interface IUserNotifier : IAsyncDisposable
 {
     public Task ShowErrorNotification(string title, string message, CancellationToken ct = default);
+    public Task ShowActionNotification(string title, string message, Action action, CancellationToken ct = default);
+
+    public void HandleActivation(AppNotificationActivatedEventArgs args);
 }
 
-public class UserNotifier : IUserNotifier
+public class UserNotifier(ILogger<UserNotifier> logger) : IUserNotifier
 {
+    private const string CoderNotificationId = "CoderNotificationId";
+
     private readonly AppNotificationManager _notificationManager = AppNotificationManager.Default;
+
+    public ConcurrentDictionary<string, Action> ActionHandlers { get; } = new();
 
     public ValueTask DisposeAsync()
     {
@@ -26,4 +36,59 @@ public class UserNotifier : IUserNotifier
         _notificationManager.Show(builder.BuildNotification());
         return Task.CompletedTask;
     }
+
+    public Task ShowActionNotification(string title, string message, Action action, CancellationToken ct = default)
+    {
+        var id = Guid.NewGuid().ToString();
+        var notification = new AppNotificationBuilder()
+            .AddText(title)
+            .AddText(message)
+            .AddArgument(CoderNotificationId, id)
+            .BuildNotification();
+        ActionHandlers[id] = action;
+        _notificationManager.Show(notification);
+        return Task.CompletedTask;
+    }
+
+    public void HandleActivation(AppNotificationActivatedEventArgs args)
+    {
+        // Must not be an Action notification.
+        if (!args.Arguments.TryGetValue(CoderNotificationId, out var id))
+            return;
+
+        if (!ActionHandlers.TryRemove(id, out var action))
+        {
+            logger.LogWarning("no action handler found for notification with ID {NotificationId}, ignoring", id);
+            return;
+        }
+
+        var dispatcherQueue = ((App)Application.Current).TrayWindow?.DispatcherQueue;
+        if (dispatcherQueue == null)
+        {
+            logger.LogError("could not acquire DispatcherQueue for notification event handling, is TrayWindow active?");
+            return;
+        }
+        if (!dispatcherQueue.HasThreadAccess)
+        {
+            dispatcherQueue.TryEnqueue(RunAction);
+            return;
+        }
+
+        RunAction();
+
+        return;
+
+        void RunAction()
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "could not handle activation for notification with ID {NotificationId}", id);
+            }
+        }
+    }
+
 }

--- a/App/Utils/ForegroundWindow.cs
+++ b/App/Utils/ForegroundWindow.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using WinRT.Interop;
+
+namespace Coder.Desktop.App.Utils;
+
+public static class ForegroundWindow
+{
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hwnd);
+
+    public static void MakeForeground(Window window)
+    {
+        var hwnd = WindowNative.GetWindowHandle(window);
+        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
+        _ = SetForegroundWindow(hwnd);
+        // Not a big deal if it fails.
+    }
+}

--- a/App/Utils/TitleBarIcon.cs
+++ b/App/Utils/TitleBarIcon.cs
@@ -1,7 +1,4 @@
-using Microsoft.UI;
-using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using WinRT.Interop;
 
 namespace Coder.Desktop.App.Utils;
 
@@ -9,8 +6,6 @@ public static class TitleBarIcon
 {
     public static void SetTitlebarIcon(Window window)
     {
-        var hwnd = WindowNative.GetWindowHandle(window);
-        var windowId = Win32Interop.GetWindowIdFromWindow(hwnd);
-        AppWindow.GetFromWindowId(windowId).SetIcon("coder.ico");
+        window.AppWindow.SetIcon("coder.ico");
     }
 }

--- a/App/ViewModels/UpdaterDownloadProgressViewModel.cs
+++ b/App/ViewModels/UpdaterDownloadProgressViewModel.cs
@@ -1,0 +1,91 @@
+using Coder.Desktop.App.Converters;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.UI.Xaml;
+using NetSparkleUpdater.Events;
+
+namespace Coder.Desktop.App.ViewModels;
+
+public partial class UpdaterDownloadProgressViewModel : ObservableObject
+{
+    // Partially implements IDownloadProgress
+    public event DownloadInstallEventHandler? DownloadProcessCompleted;
+
+    [ObservableProperty]
+    public partial bool IsDownloading { get; set; } = false;
+
+    [ObservableProperty]
+    public partial string DownloadingTitle { get; set; } = "Downloading...";
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadProgressValue))]
+    [NotifyPropertyChangedFor(nameof(UserReadableDownloadProgress))]
+    public partial ulong DownloadedBytes { get; set; } = 0;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DownloadProgressValue))]
+    [NotifyPropertyChangedFor(nameof(DownloadProgressIndeterminate))]
+    [NotifyPropertyChangedFor(nameof(UserReadableDownloadProgress))]
+    public partial ulong TotalBytes { get; set; } = 0; // 0 means unknown
+
+    public int DownloadProgressValue => (int)(TotalBytes > 0 ? DownloadedBytes * 100 / TotalBytes : 0);
+
+    public bool DownloadProgressIndeterminate => TotalBytes == 0;
+
+    public string UserReadableDownloadProgress
+    {
+        get
+        {
+            if (DownloadProgressValue == 100)
+                return "Download complete";
+
+            // TODO: FriendlyByteConverter should allow for matching suffixes
+            //       on both
+            var str = FriendlyByteConverter.FriendlyBytes(DownloadedBytes) + " of ";
+            if (TotalBytes > 0)
+                str += FriendlyByteConverter.FriendlyBytes(TotalBytes);
+            else
+                str += "unknown";
+            str += " downloaded";
+            if (DownloadProgressValue > 0)
+                str += $" ({DownloadProgressValue}%)";
+            return str;
+        }
+    }
+
+    // TODO: is this even necessary?
+    [ObservableProperty]
+    public partial string ActionButtonTitle { get; set; } = "Cancel"; // Default action string from the built-in NetSparkle UI
+
+    [ObservableProperty]
+    public partial bool IsActionButtonEnabled { get; set; } = true;
+
+    public void SetFinishedDownloading(bool isDownloadedFileValid)
+    {
+        IsDownloading = false;
+        TotalBytes = DownloadedBytes; // In case the total bytes were unknown
+        if (isDownloadedFileValid)
+        {
+            DownloadingTitle = "Ready to install";
+            ActionButtonTitle = "Install";
+        }
+
+        // We don't need to handle the error/invalid state here as the window
+        // will handle that for us by showing a MessageWindow.
+    }
+
+    public void SetDownloadProgress(ulong bytesReceived, ulong totalBytesToReceive)
+    {
+        DownloadedBytes = bytesReceived;
+        TotalBytes = totalBytesToReceive;
+    }
+
+    public void SetActionButtonEnabled(bool enabled)
+    {
+        IsActionButtonEnabled = enabled;
+    }
+
+    public void ActionButton_Click(object? sender, RoutedEventArgs e)
+    {
+        DownloadProcessCompleted?.Invoke(this, new DownloadInstallEventArgs(!IsDownloading));
+    }
+}

--- a/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
+++ b/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
@@ -1,0 +1,234 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using NetSparkleUpdater;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.Events;
+using NetSparkleUpdater.Interfaces;
+
+namespace Coder.Desktop.App.ViewModels;
+
+public interface IUpdaterUpdateAvailableViewModelFactory
+{
+    public UpdaterUpdateAvailableViewModel Create(List<AppCastItem> updates, ISignatureVerifier? signatureVerifier, string currentVersion, string appName, bool isUpdateAlreadyDownloaded);
+}
+
+public class UpdaterUpdateAvailableViewModelFactory(ILogger<UpdaterUpdateAvailableViewModel> childLogger) : IUpdaterUpdateAvailableViewModelFactory
+{
+    public UpdaterUpdateAvailableViewModel Create(List<AppCastItem> updates, ISignatureVerifier? signatureVerifier, string currentVersion, string appName, bool isUpdateAlreadyDownloaded)
+    {
+        return new UpdaterUpdateAvailableViewModel(childLogger, updates, signatureVerifier, currentVersion, appName, isUpdateAlreadyDownloaded);
+    }
+}
+
+public partial class UpdaterUpdateAvailableViewModel : ObservableObject
+{
+    private readonly ILogger<UpdaterUpdateAvailableViewModel> _logger;
+
+    // All the unchanging stuff we get from NetSparkle:
+    public readonly IReadOnlyList<AppCastItem> Updates;
+    public readonly ISignatureVerifier? SignatureVerifier;
+    public readonly string CurrentVersion;
+    public readonly string AppName;
+    public readonly bool IsUpdateAlreadyDownloaded;
+
+    // Partial implementation of IUpdateAvailable:
+    public UpdateAvailableResult Result { get; set; } = UpdateAvailableResult.None;
+    // We only show the first update.
+    public AppCastItem CurrentItem => Updates[0]; // always has at least one item
+    public event UserRespondedToUpdate? UserResponded;
+
+    // Other computed fields based on readonly data:
+    public bool MissingCriticalUpdate => Updates.Any(u => u.IsCriticalUpdate);
+
+    [ObservableProperty]
+    public partial bool ReleaseNotesVisible { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool RemindMeLaterButtonVisible { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool SkipButtonVisible { get; set; } = true;
+
+    public string MainText
+    {
+        get
+        {
+            var actionText = IsUpdateAlreadyDownloaded ? "install" : "download";
+            return $"{AppName} {CurrentItem.Version} is now available (you have {CurrentVersion}). Would you like to {actionText} it now?";
+        }
+    }
+
+    public UpdaterUpdateAvailableViewModel(ILogger<UpdaterUpdateAvailableViewModel> logger, List<AppCastItem> updates, ISignatureVerifier? signatureVerifier, string currentVersion, string appName, bool isUpdateAlreadyDownloaded)
+    {
+        if (updates.Count == 0)
+            throw new InvalidOperationException("No updates available, cannot create UpdaterUpdateAvailableViewModel");
+
+        _logger = logger;
+        Updates = updates;
+        SignatureVerifier = signatureVerifier;
+        CurrentVersion = currentVersion;
+        AppName = appName;
+        IsUpdateAlreadyDownloaded = isUpdateAlreadyDownloaded;
+    }
+
+    public void HideReleaseNotes()
+    {
+        ReleaseNotesVisible = false;
+    }
+
+    public void HideRemindMeLaterButton()
+    {
+        RemindMeLaterButtonVisible = false;
+    }
+
+    public void HideSkipButton()
+    {
+        SkipButtonVisible = false;
+    }
+
+    public async Task<string> ChangelogHtml(AppCastItem item)
+    {
+        const string cssResourceName = "Coder.Desktop.App.Assets.changelog.css";
+        const string htmlTemplate = @"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <style>
+        html, body {
+            margin: 0;
+            padding: 6px;
+            background: transparent;
+            font-family: sans-serif; /* fallback */
+            color: black;            /* fallback */
+        }
+        body {
+            /* Slightly darken the background on all themes */
+            background-color: rgba(0, 0, 0, 0.1);
+        }
+        body[data-theme=""dark""] {
+            color: white; /* fallback */
+        }
+        .markdown-body {
+            /* Slightly decrease all text size */
+            font-size: 14px; /* default 16px */
+        }
+    </style>
+
+    <style>
+{{GITHUB_MARKDOWN_CSS}}
+    </style>
+</head>
+<body data-theme=""{{THEME}}"">
+    <div class=""markdown-body"">
+        {{CONTENT}}
+    </div>
+</body>
+</html>
+";
+
+        const string githubMarkdownCssToken = "{{GITHUB_MARKDOWN_CSS}}";
+        const string themeToken = "{{THEME}}";
+        const string contentToken = "{{CONTENT}}";
+
+        // We load the CSS from an embedded asset since it's large.
+        var css = "";
+        try
+        {
+            await using var stream = typeof(App).Assembly.GetManifestResourceStream(cssResourceName)
+                                     ?? throw new FileNotFoundException($"Embedded resource not found: {cssResourceName}");
+            using var reader = new StreamReader(stream);
+            css = await reader.ReadToEndAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "failed to load changelog CSS theme from embedded asset, ignoring");
+        }
+
+        // We store the changelog in the description field, rather than using
+        // the release notes URL to avoid extra requests.
+        var innerHtml = item.Description;
+        if (string.IsNullOrWhiteSpace(innerHtml))
+        {
+            innerHtml = "<p>No release notes available.</p>";
+        }
+
+        // The theme doesn't automatically update.
+        var currentTheme = Application.Current.RequestedTheme == ApplicationTheme.Dark ? "dark" : "light";
+        return htmlTemplate
+            .Replace(githubMarkdownCssToken, css)
+            .Replace(themeToken, currentTheme)
+            .Replace(contentToken, innerHtml);
+    }
+
+    public async Task Changelog_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is not WebView2 webView)
+            return;
+
+        // Start the engine.
+        await webView.EnsureCoreWebView2Async();
+
+        // Disable unwanted features.
+        var settings = webView.CoreWebView2.Settings;
+        settings.IsScriptEnabled = false;               // disables JS
+        settings.AreHostObjectsAllowed = false;         // disables interaction with app code
+#if !DEBUG
+        settings.AreDefaultContextMenusEnabled = false; // disables right-click
+        settings.AreDevToolsEnabled = false;
+#endif
+        settings.IsZoomControlEnabled = false;
+        settings.IsStatusBarEnabled = false;
+
+        // Hijack navigation to prevent links opening in the web view.
+        webView.CoreWebView2.NavigationStarting += (_, e) =>
+        {
+            // webView.NavigateToString uses data URIs, so allow those to work.
+            if (e.Uri.StartsWith("data:text/html", StringComparison.OrdinalIgnoreCase))
+                return;
+
+            // Prevent the web view from trying to navigate to it.
+            e.Cancel = true;
+
+            // Launch HTTP or HTTPS URLs in the default browser.
+            if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri) && uri is { Scheme: "http" or "https" })
+                Process.Start(new ProcessStartInfo(e.Uri) { UseShellExecute = true });
+        };
+
+        var html = await ChangelogHtml(CurrentItem);
+        webView.NavigateToString(html);
+    }
+
+    private void SendResponse(UpdateAvailableResult result)
+    {
+        Result = result;
+        UserResponded?.Invoke(this, new UpdateResponseEventArgs(result, CurrentItem));
+    }
+
+    public void SkipButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (!SkipButtonVisible || MissingCriticalUpdate)
+            return;
+        SendResponse(UpdateAvailableResult.SkipUpdate);
+    }
+
+    public void RemindMeLaterButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (!RemindMeLaterButtonVisible || MissingCriticalUpdate)
+            return;
+        SendResponse(UpdateAvailableResult.RemindMeLater);
+    }
+
+    public void InstallButton_Click(object sender, RoutedEventArgs e)
+    {
+        SendResponse(UpdateAvailableResult.InstallUpdate);
+    }
+}

--- a/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
+++ b/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
@@ -189,6 +189,7 @@ public partial class UpdaterUpdateAvailableViewModel : ObservableObject
         settings.IsStatusBarEnabled = false;
 
         // Hijack navigation to prevent links opening in the web view.
+        // TODO: block new windows as well
         webView.CoreWebView2.NavigationStarting += (_, e) =>
         {
             // webView.NavigateToString uses data URIs, so allow those to work.

--- a/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
+++ b/App/ViewModels/UpdaterUpdateAvailableViewModel.cs
@@ -189,7 +189,6 @@ public partial class UpdaterUpdateAvailableViewModel : ObservableObject
         settings.IsStatusBarEnabled = false;
 
         // Hijack navigation to prevent links opening in the web view.
-        // TODO: block new windows as well
         webView.CoreWebView2.NavigationStarting += (_, e) =>
         {
             // webView.NavigateToString uses data URIs, so allow those to work.
@@ -199,6 +198,14 @@ public partial class UpdaterUpdateAvailableViewModel : ObservableObject
             // Prevent the web view from trying to navigate to it.
             e.Cancel = true;
 
+            // Launch HTTP or HTTPS URLs in the default browser.
+            if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri) && uri is { Scheme: "http" or "https" })
+                Process.Start(new ProcessStartInfo(e.Uri) { UseShellExecute = true });
+        };
+        webView.CoreWebView2.NewWindowRequested += (_, e) =>
+        {
+            // Prevent new windows from being launched (e.g. target="_blank").
+            e.Handled = true;
             // Launch HTTP or HTTPS URLs in the default browser.
             if (Uri.TryCreate(e.Uri, UriKind.Absolute, out var uri) && uri is { Scheme: "http" or "https" })
                 Process.Start(new ProcessStartInfo(e.Uri) { UseShellExecute = true });

--- a/App/Views/MessageWindow.xaml
+++ b/App/Views/MessageWindow.xaml
@@ -12,7 +12,7 @@
     MinWidth="500" MinHeight="240">
 
     <Window.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
+        <MicaBackdrop />
     </Window.SystemBackdrop>
 
     <Grid Padding="24">

--- a/App/Views/MessageWindow.xaml
+++ b/App/Views/MessageWindow.xaml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winuiex:WindowEx
+    x:Class="Coder.Desktop.App.Views.MessageWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:winuiex="using:WinUIEx"
+    mc:Ignorable="d"
+    IsMaximizable="False"
+    Width="500" Height="240"
+    MinWidth="500" MinHeight="240">
+
+    <Window.SystemBackdrop>
+        <DesktopAcrylicBackdrop />
+    </Window.SystemBackdrop>
+
+    <Grid Padding="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Style="{ThemeResource SubtitleTextBlockStyle}"
+                   Text="{x:Bind MessageTitle}"
+                   TextWrapping="WrapWholeWords"
+                   IsTextSelectionEnabled="True"
+                   Margin="0,0,0,8" />
+
+        <TextBlock Grid.Row="1"
+                   Text="{x:Bind MessageContent}"
+                   IsTextSelectionEnabled="True"
+                   TextWrapping="WrapWholeWords" />
+
+        <Button Grid.Row="2"
+                Content="Close"
+                Margin="0,24,0,0"
+                HorizontalAlignment="Right"
+                Click="CloseClicked" />
+    </Grid>
+</winuiex:WindowEx>

--- a/App/Views/MessageWindow.xaml.cs
+++ b/App/Views/MessageWindow.xaml.cs
@@ -1,9 +1,5 @@
-using System.Diagnostics;
-using Windows.Foundation;
-using Windows.Graphics;
 using Coder.Desktop.App.Utils;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Media;
 using WinUIEx;
 
 namespace Coder.Desktop.App.Views;
@@ -21,7 +17,6 @@ public sealed partial class MessageWindow : WindowEx
 
         InitializeComponent();
         TitleBarIcon.SetTitlebarIcon(this);
-        SystemBackdrop = new DesktopAcrylicBackdrop();
         this.CenterOnScreen();
         AppWindow.Show();
 

--- a/App/Views/MessageWindow.xaml.cs
+++ b/App/Views/MessageWindow.xaml.cs
@@ -1,0 +1,37 @@
+using System.Diagnostics;
+using Windows.Foundation;
+using Windows.Graphics;
+using Coder.Desktop.App.Utils;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+using WinUIEx;
+
+namespace Coder.Desktop.App.Views;
+
+public sealed partial class MessageWindow : WindowEx
+{
+    public string MessageTitle;
+    public string MessageContent;
+
+    public MessageWindow(string title, string content, string windowTitle = "Coder Desktop")
+    {
+        Title = windowTitle;
+        MessageTitle = title;
+        MessageContent = content;
+
+        InitializeComponent();
+        TitleBarIcon.SetTitlebarIcon(this);
+        SystemBackdrop = new DesktopAcrylicBackdrop();
+        this.CenterOnScreen();
+        AppWindow.Show();
+
+        // TODO: the window should resize to fit content and not be resizable
+        //       by the user, probably possible with SizedFrame and a Page, but
+        //       I didn't want to add a Page for this
+    }
+
+    public void CloseClicked(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+}

--- a/App/Views/Pages/UpdaterDownloadProgressMainPage.xaml
+++ b/App/Views/Pages/UpdaterDownloadProgressMainPage.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="Coder.Desktop.App.Views.Pages.UpdaterDownloadProgressMainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Orientation="Vertical" Padding="24">
+        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                   Text="{x:Bind ViewModel.DownloadingTitle, Mode=OneWay}"
+                   Margin="0,0,0,16" />
+
+        <ProgressBar Value="{x:Bind ViewModel.DownloadProgressValue, Mode=OneWay}"
+                     IsIndeterminate="{x:Bind ViewModel.DownloadProgressIndeterminate, Mode=OneWay}"
+                     Margin="0,0,0,24"
+                     HorizontalAlignment="Stretch" />
+
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <TextBlock Grid.Column="0"
+                       Style="{ThemeResource CaptionTextBlockStyle}"
+                       Text="{x:Bind ViewModel.UserReadableDownloadProgress, Mode=OneWay}"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Center"
+                       Margin="0,0,24,0" />
+
+            <Button Grid.Column="1"
+                    Content="{x:Bind ViewModel.ActionButtonTitle, Mode=OneWay}"
+                    IsEnabled="{x:Bind ViewModel.IsActionButtonEnabled, Mode=OneWay}"
+                    HorizontalAlignment="Right"
+                    Click="{x:Bind ViewModel.ActionButton_Click}" />
+        </Grid>
+    </StackPanel>
+</Page>

--- a/App/Views/Pages/UpdaterDownloadProgressMainPage.xaml.cs
+++ b/App/Views/Pages/UpdaterDownloadProgressMainPage.xaml.cs
@@ -1,0 +1,14 @@
+using Microsoft.UI.Xaml.Controls;
+using Coder.Desktop.App.ViewModels;
+
+namespace Coder.Desktop.App.Views.Pages;
+
+public sealed partial class UpdaterDownloadProgressMainPage : Page
+{
+    public readonly UpdaterDownloadProgressViewModel ViewModel;
+    public UpdaterDownloadProgressMainPage(UpdaterDownloadProgressViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        InitializeComponent();
+    }
+}

--- a/App/Views/Pages/UpdaterUpdateAvailableMainPage.xaml
+++ b/App/Views/Pages/UpdaterUpdateAvailableMainPage.xaml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="Coder.Desktop.App.Views.Pages.UpdaterUpdateAvailableMainPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Page.Resources>
+        <!-- Apply a lighter or darker border and background based on theme. -->
+        <SolidColorBrush x:Key="ChangelogBorderBrush"
+                         Color="{ThemeResource TextFillColorPrimaryBrush}"
+                         Opacity="0.3" />
+    </Page.Resources>
+
+    <Grid Padding="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0"
+                   Style="{ThemeResource SubtitleTextBlockStyle}"
+                   Text="Updates available"
+                   Margin="0,0,0,16" />
+
+        <TextBlock Grid.Row="1"
+                   Text="{x:Bind ViewModel.MainText}"
+                   TextWrapping="WrapWholeWords"
+                   IsTextSelectionEnabled="True"
+                   Margin="0,0,0,24"/>
+
+        <TextBlock Grid.Row="2"
+                   Style="{ThemeResource BodyStrongTextBlockStyle}"
+                   Text="Release notes:"
+                   Margin="0,0,0,8"/>
+
+        <!--
+            TODO: it'd be nice to get this to have rounded corners and true
+                  transparency, but unfortunately it seems impossible
+        -->
+        <Border Grid.Row="3"
+                BorderBrush="{ThemeResource ChangelogBorderBrush}"
+                Margin="0,0,0,16">
+
+            <!-- We disable JS and navigation in this web view for security -->
+            <WebView2 DefaultBackgroundColor="Transparent"
+                      Loaded="{x:Bind ViewModel.Changelog_Loaded}" />
+        </Border>
+
+        <Grid Grid.Row="4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" /> <!-- empty -->
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+
+            <Button Grid.Column="0"
+                    Content="Skip this version"
+                    IsEnabled="{x:Bind ViewModel.MissingCriticalUpdate, Converter={StaticResource InverseBoolConverter}}"
+                    Visibility="{x:Bind ViewModel.SkipButtonVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                    Click="{x:Bind ViewModel.SkipButton_Click}" />
+
+            <!-- skip for float -->
+
+            <Button Grid.Column="2"
+                    Content="Remind me later"
+                    IsEnabled="{x:Bind ViewModel.MissingCriticalUpdate, Converter={StaticResource InverseBoolConverter}}"
+                    Visibility="{x:Bind ViewModel.RemindMeLaterButtonVisible, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                    Click="{x:Bind ViewModel.RemindMeLaterButton_Click}"
+                    Margin="0,0,8,0" />
+
+            <Button Grid.Column="3"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Content="Install update"
+                    Click="{x:Bind ViewModel.InstallButton_Click}" />
+        </Grid>
+    </Grid>
+</Page>

--- a/App/Views/Pages/UpdaterUpdateAvailableMainPage.xaml.cs
+++ b/App/Views/Pages/UpdaterUpdateAvailableMainPage.xaml.cs
@@ -1,0 +1,15 @@
+using Microsoft.UI.Xaml.Controls;
+using Coder.Desktop.App.ViewModels;
+
+namespace Coder.Desktop.App.Views.Pages;
+
+public sealed partial class UpdaterUpdateAvailableMainPage : Page
+{
+    public readonly UpdaterUpdateAvailableViewModel ViewModel;
+
+    public UpdaterUpdateAvailableMainPage(UpdaterUpdateAvailableViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        InitializeComponent();
+    }
+}

--- a/App/Views/TrayWindow.xaml
+++ b/App/Views/TrayWindow.xaml
@@ -15,7 +15,7 @@
     </Window.SystemBackdrop>
 
     <Grid>
-        <!-- For some strange reason, setting OpenCommand and ExitCommand here doesn't work, see .cs -->
+        <!-- For some strange reason, setting commands here doesn't work, see .cs -->
         <controls:TrayIcon x:Name="TrayIcon" />
 
         <!-- This is where the current Page is displayed -->

--- a/App/Views/UpdaterCheckingForUpdatesWindow.xaml
+++ b/App/Views/UpdaterCheckingForUpdatesWindow.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winuiex:WindowEx
+    x:Class="Coder.Desktop.App.Views.UpdaterCheckingForUpdatesWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:winuiex="using:WinUIEx"
+    mc:Ignorable="d"
+    Title="Coder Desktop Updater"
+    IsResizable="false"
+    IsMaximizable="false"
+    Width="500" Height="190">
+
+    <Window.SystemBackdrop>
+        <DesktopAcrylicBackdrop />
+    </Window.SystemBackdrop>
+
+    <StackPanel Orientation="Vertical" Padding="32">
+        <ProgressRing IsActive="True"
+                      Margin="0,0,0,20"
+                      HorizontalAlignment="Center"/>
+
+        <TextBlock Style="{ThemeResource SubtitleTextBlockStyle}"
+                   Text="Checking for updates..."
+                   HorizontalAlignment="Center" />
+    </StackPanel>
+</winuiex:WindowEx>

--- a/App/Views/UpdaterCheckingForUpdatesWindow.xaml
+++ b/App/Views/UpdaterCheckingForUpdatesWindow.xaml
@@ -13,7 +13,7 @@
     Width="500" Height="190">
 
     <Window.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
+        <MicaBackdrop />
     </Window.SystemBackdrop>
 
     <StackPanel Orientation="Vertical" Padding="32">

--- a/App/Views/UpdaterCheckingForUpdatesWindow.xaml.cs
+++ b/App/Views/UpdaterCheckingForUpdatesWindow.xaml.cs
@@ -1,4 +1,3 @@
-using Microsoft.UI.Xaml.Media;
 using System;
 using Coder.Desktop.App.Utils;
 using NetSparkleUpdater.Interfaces;
@@ -15,7 +14,6 @@ public sealed partial class UpdaterCheckingForUpdatesWindow : WindowEx, ICheckin
     {
         InitializeComponent();
         TitleBarIcon.SetTitlebarIcon(this);
-        SystemBackdrop = new DesktopAcrylicBackdrop();
         AppWindow.Hide();
 
         Closed += (_, _) => UpdatesUIClosing?.Invoke(this, EventArgs.Empty);

--- a/App/Views/UpdaterCheckingForUpdatesWindow.xaml.cs
+++ b/App/Views/UpdaterCheckingForUpdatesWindow.xaml.cs
@@ -1,0 +1,34 @@
+using Microsoft.UI.Xaml.Media;
+using System;
+using Coder.Desktop.App.Utils;
+using NetSparkleUpdater.Interfaces;
+using WinUIEx;
+
+namespace Coder.Desktop.App.Views;
+
+public sealed partial class UpdaterCheckingForUpdatesWindow : WindowEx, ICheckingForUpdates
+{
+    // Implements ICheckingForUpdates
+    public event EventHandler? UpdatesUIClosing;
+
+    public UpdaterCheckingForUpdatesWindow()
+    {
+        InitializeComponent();
+        TitleBarIcon.SetTitlebarIcon(this);
+        SystemBackdrop = new DesktopAcrylicBackdrop();
+        AppWindow.Hide();
+
+        Closed += (_, _) => UpdatesUIClosing?.Invoke(this, EventArgs.Empty);
+    }
+
+    void ICheckingForUpdates.Show()
+    {
+        AppWindow.Show();
+        this.CenterOnScreen();
+    }
+
+    void ICheckingForUpdates.Close()
+    {
+        Close();
+    }
+}

--- a/App/Views/UpdaterDownloadProgressWindow.xaml
+++ b/App/Views/UpdaterDownloadProgressWindow.xaml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winuiex:WindowEx
+    x:Class="Coder.Desktop.App.Views.UpdaterDownloadProgressWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:winuiex="using:WinUIEx"
+    mc:Ignorable="d"
+    Title="Coder Desktop Updater"
+    IsMaximizable="False"
+    Width="500" Height="190"
+    MinWidth="500" MinHeight="190">
+
+    <Window.SystemBackdrop>
+        <DesktopAcrylicBackdrop />
+    </Window.SystemBackdrop>
+
+    <Frame x:Name="RootFrame" />
+</winuiex:WindowEx>

--- a/App/Views/UpdaterDownloadProgressWindow.xaml
+++ b/App/Views/UpdaterDownloadProgressWindow.xaml
@@ -13,7 +13,7 @@
     MinWidth="500" MinHeight="190">
 
     <Window.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
+        <MicaBackdrop />
     </Window.SystemBackdrop>
 
     <Frame x:Name="RootFrame" />

--- a/App/Views/UpdaterDownloadProgressWindow.xaml.cs
+++ b/App/Views/UpdaterDownloadProgressWindow.xaml.cs
@@ -1,0 +1,85 @@
+using Microsoft.UI.Xaml.Media;
+using Coder.Desktop.App.Utils;
+using Coder.Desktop.App.ViewModels;
+using Coder.Desktop.App.Views.Pages;
+using NetSparkleUpdater.Events;
+using NetSparkleUpdater.Interfaces;
+using WinUIEx;
+using WindowEventArgs = Microsoft.UI.Xaml.WindowEventArgs;
+
+namespace Coder.Desktop.App.Views;
+
+public sealed partial class UpdaterDownloadProgressWindow : WindowEx, IDownloadProgress
+{
+    // Implements IDownloadProgress
+    public event DownloadInstallEventHandler? DownloadProcessCompleted;
+
+    public UpdaterDownloadProgressViewModel ViewModel;
+
+    private bool _didCallDownloadProcessCompletedHandler;
+
+    public UpdaterDownloadProgressWindow(UpdaterDownloadProgressViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        ViewModel.DownloadProcessCompleted += (_, args) => SendResponse(args);
+
+        InitializeComponent();
+        TitleBarIcon.SetTitlebarIcon(this);
+        SystemBackdrop = new DesktopAcrylicBackdrop();
+        AppWindow.Hide();
+
+        RootFrame.Content = new UpdaterDownloadProgressMainPage(ViewModel);
+
+        Closed += UpdaterDownloadProgressWindow_Closed;
+    }
+
+    public void SendResponse(DownloadInstallEventArgs args)
+    {
+        if (_didCallDownloadProcessCompletedHandler)
+            return;
+        _didCallDownloadProcessCompletedHandler = true;
+        DownloadProcessCompleted?.Invoke(this, args);
+    }
+
+    private void UpdaterDownloadProgressWindow_Closed(object sender, WindowEventArgs args)
+    {
+        SendResponse(new DownloadInstallEventArgs(false)); // Cancel
+    }
+
+    void IDownloadProgress.SetDownloadAndInstallButtonEnabled(bool shouldBeEnabled)
+    {
+        ViewModel.SetActionButtonEnabled(shouldBeEnabled);
+    }
+
+    void IDownloadProgress.Show()
+    {
+        AppWindow.Show();
+        this.CenterOnScreen();
+    }
+
+    void IDownloadProgress.Close()
+    {
+        Close();
+    }
+
+    void IDownloadProgress.OnDownloadProgressChanged(object sender, ItemDownloadProgressEventArgs args)
+    {
+        ViewModel.SetDownloadProgress((ulong)args.BytesReceived, (ulong)args.TotalBytesToReceive);
+    }
+
+    void IDownloadProgress.FinishedDownloadingFile(bool isDownloadedFileValid)
+    {
+        ViewModel.SetFinishedDownloading(isDownloadedFileValid);
+    }
+
+    bool IDownloadProgress.DisplayErrorMessage(string errorMessage)
+    {
+        // TODO: this is pretty lazy but works for now
+        _ = new MessageWindow(
+            "Download failed",
+            errorMessage,
+            "Coder Desktop Updater");
+        Close();
+        return true;
+    }
+}

--- a/App/Views/UpdaterDownloadProgressWindow.xaml.cs
+++ b/App/Views/UpdaterDownloadProgressWindow.xaml.cs
@@ -1,4 +1,3 @@
-using Microsoft.UI.Xaml.Media;
 using Coder.Desktop.App.Utils;
 using Coder.Desktop.App.ViewModels;
 using Coder.Desktop.App.Views.Pages;
@@ -16,7 +15,7 @@ public sealed partial class UpdaterDownloadProgressWindow : WindowEx, IDownloadP
 
     public UpdaterDownloadProgressViewModel ViewModel;
 
-    private bool _didCallDownloadProcessCompletedHandler;
+    private bool _downloadProcessCompletedInvoked;
 
     public UpdaterDownloadProgressWindow(UpdaterDownloadProgressViewModel viewModel)
     {
@@ -25,7 +24,6 @@ public sealed partial class UpdaterDownloadProgressWindow : WindowEx, IDownloadP
 
         InitializeComponent();
         TitleBarIcon.SetTitlebarIcon(this);
-        SystemBackdrop = new DesktopAcrylicBackdrop();
         AppWindow.Hide();
 
         RootFrame.Content = new UpdaterDownloadProgressMainPage(ViewModel);
@@ -35,9 +33,9 @@ public sealed partial class UpdaterDownloadProgressWindow : WindowEx, IDownloadP
 
     public void SendResponse(DownloadInstallEventArgs args)
     {
-        if (_didCallDownloadProcessCompletedHandler)
+        if (_downloadProcessCompletedInvoked)
             return;
-        _didCallDownloadProcessCompletedHandler = true;
+        _downloadProcessCompletedInvoked = true;
         DownloadProcessCompleted?.Invoke(this, args);
     }
 

--- a/App/Views/UpdaterUpdateAvailableWindow.xaml
+++ b/App/Views/UpdaterUpdateAvailableWindow.xaml
@@ -14,7 +14,7 @@
     MinWidth="600" MinHeight="500">
 
     <Window.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
+        <MicaBackdrop />
     </Window.SystemBackdrop>
 
     <Frame x:Name="RootFrame" />

--- a/App/Views/UpdaterUpdateAvailableWindow.xaml
+++ b/App/Views/UpdaterUpdateAvailableWindow.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<winuiex:WindowEx
+    x:Class="Coder.Desktop.App.Views.UpdaterUpdateAvailableWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:winuiex="using:WinUIEx"
+    mc:Ignorable="d"
+    Title="Coder Desktop Updater"
+    IsResizable="True"
+    IsMaximizable="False"
+    Width="600" Height="500"
+    MinWidth="600" MinHeight="500">
+
+    <Window.SystemBackdrop>
+        <DesktopAcrylicBackdrop />
+    </Window.SystemBackdrop>
+
+    <Frame x:Name="RootFrame" />
+</winuiex:WindowEx>

--- a/App/Views/UpdaterUpdateAvailableWindow.xaml.cs
+++ b/App/Views/UpdaterUpdateAvailableWindow.xaml.cs
@@ -1,0 +1,90 @@
+using Microsoft.UI.Xaml.Media;
+using Coder.Desktop.App.Utils;
+using Coder.Desktop.App.ViewModels;
+using Coder.Desktop.App.Views.Pages;
+using Microsoft.UI.Xaml;
+using NetSparkleUpdater;
+using NetSparkleUpdater.Enums;
+using NetSparkleUpdater.Events;
+using NetSparkleUpdater.Interfaces;
+using WinUIEx;
+
+namespace Coder.Desktop.App.Views;
+
+public sealed partial class UpdaterUpdateAvailableWindow : WindowEx, IUpdateAvailable
+{
+    public readonly UpdaterUpdateAvailableViewModel ViewModel;
+
+    // Implements IUpdateAvailable
+    public UpdateAvailableResult Result => ViewModel.Result;
+    // Implements IUpdateAvailable
+    public AppCastItem CurrentItem => ViewModel.CurrentItem;
+    // Implements IUpdateAvailable
+    public event UserRespondedToUpdate? UserResponded;
+
+    private bool _respondedToUpdate;
+
+    public UpdaterUpdateAvailableWindow(UpdaterUpdateAvailableViewModel viewModel)
+    {
+        ViewModel = viewModel;
+        ViewModel.UserResponded += (_, args) =>
+            UserRespondedToUpdateCheck(args.Result);
+
+        InitializeComponent();
+        TitleBarIcon.SetTitlebarIcon(this);
+        SystemBackdrop = new DesktopAcrylicBackdrop();
+        AppWindow.Hide();
+
+        RootFrame.Content = new UpdaterUpdateAvailableMainPage(ViewModel);
+
+        Closed += UpdaterUpdateAvailableWindow_Closed;
+    }
+
+    private void UpdaterUpdateAvailableWindow_Closed(object sender, WindowEventArgs args)
+    {
+        UserRespondedToUpdateCheck(UpdateAvailableResult.None);
+    }
+
+    void IUpdateAvailable.Show()
+    {
+        AppWindow.Show();
+        this.CenterOnScreen();
+    }
+
+    void IUpdateAvailable.Close()
+    {
+        UserRespondedToUpdateCheck(UpdateAvailableResult.None); // the Avalonia UI does this "just in case"
+        Close();
+    }
+
+    void IUpdateAvailable.HideReleaseNotes()
+    {
+        ViewModel.HideReleaseNotes();
+    }
+
+    void IUpdateAvailable.HideRemindMeLaterButton()
+    {
+        ViewModel.HideRemindMeLaterButton();
+    }
+
+    void IUpdateAvailable.HideSkipButton()
+    {
+        ViewModel.HideSkipButton();
+    }
+
+    void IUpdateAvailable.BringToFront()
+    {
+        Activate();
+        ForegroundWindow.MakeForeground(this);
+    }
+
+    private void UserRespondedToUpdateCheck(UpdateAvailableResult response)
+    {
+        if (_respondedToUpdate)
+            return;
+        _respondedToUpdate = true;
+        UserResponded?.Invoke(this, new UpdateResponseEventArgs(response, CurrentItem));
+        // Prevent further interaction.
+        Close();
+    }
+}

--- a/App/Views/UpdaterUpdateAvailableWindow.xaml.cs
+++ b/App/Views/UpdaterUpdateAvailableWindow.xaml.cs
@@ -1,4 +1,3 @@
-using Microsoft.UI.Xaml.Media;
 using Coder.Desktop.App.Utils;
 using Coder.Desktop.App.ViewModels;
 using Coder.Desktop.App.Views.Pages;
@@ -32,7 +31,6 @@ public sealed partial class UpdaterUpdateAvailableWindow : WindowEx, IUpdateAvai
 
         InitializeComponent();
         TitleBarIcon.SetTitlebarIcon(this);
-        SystemBackdrop = new DesktopAcrylicBackdrop();
         AppWindow.Hide();
 
         RootFrame.Content = new UpdaterUpdateAvailableMainPage(ViewModel);
@@ -53,7 +51,8 @@ public sealed partial class UpdaterUpdateAvailableWindow : WindowEx, IUpdateAvai
 
     void IUpdateAvailable.Close()
     {
-        UserRespondedToUpdateCheck(UpdateAvailableResult.None); // the Avalonia UI does this "just in case"
+        // The NetSparkle built-in Avalonia UI does this "just in case"
+        UserRespondedToUpdateCheck(UpdateAvailableResult.None);
         Close();
     }
 

--- a/App/packages.lock.json
+++ b/App/packages.lock.json
@@ -105,6 +105,15 @@
           "Microsoft.Windows.SDK.BuildTools": "10.0.22621.756"
         }
       },
+      "NetSparkleUpdater.SparkleUpdater": {
+        "type": "Direct",
+        "requested": "[3.0.2, )",
+        "resolved": "3.0.2",
+        "contentHash": "ruDV/hBjZX7DTFMvcJAgA8bUEB8zkq23i/zwpKKWr/vK/IxWIQESYRfP2JpQfKSqlVFNL5uOlJ86wV6nJAi09w==",
+        "dependencies": {
+          "NetSparkleUpdater.Chaos.NaCl": "0.9.3"
+        }
+      },
       "Serilog.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[9.0.0, )",
@@ -127,6 +136,15 @@
           "Microsoft.Extensions.Configuration.Binder": "9.0.0",
           "Microsoft.Extensions.DependencyModel": "9.0.0",
           "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Direct",
+        "requested": "[3.0.0, )",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
         }
       },
       "Serilog.Sinks.File": {
@@ -455,6 +473,11 @@
         "type": "Transitive",
         "resolved": "10.0.22621.756",
         "contentHash": "7ZL2sFSioYm1Ry067Kw1hg0SCcW5kuVezC2SwjGbcPE61Nn+gTbH86T73G3LcEOVj0S3IZzNuE/29gZvOLS7VA=="
+      },
+      "NetSparkleUpdater.Chaos.NaCl": {
+        "type": "Transitive",
+        "resolved": "0.9.3",
+        "contentHash": "Copo3+rYuRVOuc6fmzHwXwehDC8l8DQ3y2VRI/d0sQTwProL4QAjkxRPV0zr3XBz1A8ZODXATOXV0hJXc7YdKg=="
       },
       "Semver": {
         "type": "Transitive",

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -263,7 +263,6 @@ public class Program
         programFiles64Folder.AddDir(installDir);
         project.AddDir(programFiles64Folder);
 
-
         project.AddRegValues(
             // Add registry values that are consumed by the manager. Note that these
             // should not be changed. See Vpn.Service/Program.cs (AddDefaultConfig) and

--- a/Tests.Vpn.Service/DownloaderTest.cs
+++ b/Tests.Vpn.Service/DownloaderTest.cs
@@ -323,6 +323,7 @@ public class DownloaderTest
             ctx.Response.ContentType = "text/plain";
             // Don't set Content-Length.
             await ctx.Response.OutputStream.WriteAsync("test"u8.ToArray(), ct);
+            await ctx.Response.OutputStream.FlushAsync(ct);
         });
         var url = new Uri(httpServer.BaseUrl + "/test");
         var destPath = Path.Combine(_tempDir, "test");
@@ -345,6 +346,7 @@ public class DownloaderTest
             ctx.Response.Headers.Add("X-Original-Content-Length", "5"); // incorrect
             ctx.Response.ContentType = "text/plain";
             await ctx.Response.OutputStream.WriteAsync("test"u8.ToArray(), ct);
+            await ctx.Response.OutputStream.FlushAsync(ct);
         });
         var url = new Uri(httpServer.BaseUrl + "/test");
         var destPath = Path.Combine(_tempDir, "test");

--- a/Vpn.Proto/packages.lock.json
+++ b/Vpn.Proto/packages.lock.json
@@ -13,9 +13,6 @@
         "requested": "[2.69.0, )",
         "resolved": "2.69.0",
         "contentHash": "W5hW4R1h19FCzKb8ToqIJMI5YxnQqGmREEpV8E5XkfCtLPIK5MSHztwQ8gZUfG8qu9fg5MhItjzyPRqQBjnrbA=="
-      },
-      "Coder.Desktop.CoderSdk": {
-        "type": "Project"
       }
     }
   }

--- a/scripts/Create-AppCastSigningKey.ps1
+++ b/scripts/Create-AppCastSigningKey.ps1
@@ -1,0 +1,27 @@
+# This is mostly just here for reference.
+#
+# Usage: Create-AppCastSigningKey.ps1 -outputKeyPath <path>
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $outputKeyPath
+)
+
+$ErrorActionPreference = "Stop"
+
+& openssl.exe genpkey -algorithm ed25519 -out $outputKeyPath
+if ($LASTEXITCODE -ne 0) { throw "Failed to generate ED25519 private key" }
+
+# Export the public key in DER format
+$pubKeyDerPath = "$outputKeyPath.pub.der"
+& openssl.exe pkey -in $outputKeyPath -pubout -outform DER -out $pubKeyDerPath
+if ($LASTEXITCODE -ne 0) { throw "Failed to export ED25519 public key" }
+
+# Remove the DER header to get the actual key bytes
+$pubBytes = [System.IO.File]::ReadAllBytes($pubKeyDerPath)[-32..-1]
+Remove-Item $pubKeyDerPath
+
+# Base64 encode and print
+Write-Output "NetSparkle formatted public key:"
+Write-Output ([Convert]::ToBase64String($pubBytes))
+Write-Output ""
+Write-Output "Private key written to $outputKeyPath"

--- a/scripts/Get-Mutagen.ps1
+++ b/scripts/Get-Mutagen.ps1
@@ -5,6 +5,8 @@ param (
     [string] $arch
 )
 
+$ErrorActionPreference = "Stop"
+
 function Download-File([string] $url, [string] $outputPath, [string] $etagFile) {
     Write-Host "Downloading '$url' to '$outputPath'"
     # We use `curl.exe` here because `Invoke-WebRequest` is notoriously slow.

--- a/scripts/Get-WindowsAppSdk.ps1
+++ b/scripts/Get-WindowsAppSdk.ps1
@@ -5,6 +5,8 @@ param (
     [string] $arch
 )
 
+$ErrorActionPreference = "Stop"
+
 function Download-File([string] $url, [string] $outputPath, [string] $etagFile) {
     Write-Host "Downloading '$url' to '$outputPath'"
     # We use `curl.exe` here because `Invoke-WebRequest` is notoriously slow.

--- a/scripts/Update-AppCast.ps1
+++ b/scripts/Update-AppCast.ps1
@@ -15,9 +15,11 @@
 #          -outputAppCastSignaturePath <path>
 param (
     [Parameter(Mandatory = $true)]
+    [ValidatePattern("^v\d+\.\d+\.\d+$")]
     [string] $tag,
 
     [Parameter(Mandatory = $true)]
+    [ValidatePattern("^\d+\.\d+\.\d+$")]
     [string] $version,
 
     [Parameter(Mandatory = $true)]

--- a/scripts/Update-AppCast.ps1
+++ b/scripts/Update-AppCast.ps1
@@ -1,0 +1,194 @@
+# Updates appcast.xml and appcast.xml.signature for a given release.
+#
+# Requires openssl.exe. You can install it via winget:
+#   winget install ShiningLight.OpenSSL.Light
+#
+# Usage: Update-AppCast.ps1
+#          -tag <tag>
+#          -version <version>
+#          -channel <stable|preview>
+#          -x64Path <path>
+#          -arm64Path <path>
+#          -keyPath <path>
+#          -inputAppCastPath <path>
+#          -outputAppCastPath <path>
+#          -outputAppCastSignaturePath <path>
+param (
+    [Parameter(Mandatory = $true)]
+    [string] $tag,
+
+    [Parameter(Mandatory = $true)]
+    [string] $version,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('stable', 'preview')]
+    [string] $channel,
+
+    [Parameter(Mandatory = $false)]
+    [string] $pubDate = (Get-Date).ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss +0000"),
+
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string] $x64Path,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string] $arm64Path,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
+    [string] $keyPath,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateScript({ Test-Path $_ })]
+    [string] $inputAppCastPath = "appcast.xml",
+
+    [Parameter(Mandatory = $false)]
+    [string] $outputAppCastPath = "appcast.xml",
+
+    [Parameter(Mandatory = $false)]
+    [string] $outputAppCastSignaturePath = "appcast.xml.signature"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repo = "coder/coder-desktop-windows"
+
+function Get-Ed25519Signature {
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateScript({ Test-Path $_ })]
+        [string] $path
+    )
+
+    # Use a temporary file. We can't just pipe directly because PowerShell
+    # operates with strings for third party commands.
+    $tempPath = Join-Path $env:TEMP "coder-desktop-temp.bin"
+    & openssl.exe pkeyutl -sign -inkey $keyPath -rawin -in $path -out $tempPath
+    if ($LASTEXITCODE -ne 0) { throw "Failed to sign file: $path" }
+    $signature = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($tempPath))
+    Remove-Item -Force $tempPath
+    return $signature
+}
+
+# Retrieve the release notes from the GitHub releases API
+$releaseNotesMarkdown = & gh.exe release view $tag `
+    --json body `
+    --jq ".body"
+if ($LASTEXITCODE -ne 0) { throw "Failed to retrieve release notes markdown" }
+$releaseNotesMarkdown = $releaseNotesMarkdown -replace "`r`n", "`n"
+$releaseNotesMarkdownPath = Join-Path $env:TEMP "coder-desktop-release-notes.md"
+Set-Content -Path $releaseNotesMarkdownPath -Value $releaseNotesMarkdown -Encoding UTF8
+
+Write-Output "---- Release Notes Markdown -----"
+Get-Content $releaseNotesMarkdownPath
+Write-Output "---- End of Release Notes Markdown ----"
+Write-Output ""
+
+# Convert the release notes markdown to HTML using the GitHub API to match
+# GitHub's formatting
+$releaseNotesHtmlPath = Join-Path $env:TEMP "coder-desktop-release-notes.html"
+& gh.exe api `
+    --method POST `
+    -H "Accept: application/vnd.github+json" `
+    -H "X-GitHub-Api-Version: 2022-11-28" `
+    /markdown `
+    -F "text=@$releaseNotesMarkdownPath" `
+    -F "mode=gfm" `
+    -F "context=$repo" `
+    > $releaseNotesHtmlPath
+if ($LASTEXITCODE -ne 0) { throw "Failed to convert release notes markdown to HTML" }
+
+Write-Output "---- Release Notes HTML -----"
+Get-Content $releaseNotesHtmlPath
+Write-Output "---- End of Release Notes HTML ----"
+Write-Output ""
+
+[xml] $appCast = Get-Content $inputAppCastPath
+
+# Set up namespace manager for sparkle: prefix
+$nsManager = New-Object System.Xml.XmlNamespaceManager($appCast.NameTable)
+$nsManager.AddNamespace("sparkle", "http://www.andymatuschak.org/xml-namespaces/sparkle")
+
+# Find the matching channel item
+$channelItem = $appCast.SelectSingleNode("//item[sparkle:channel='$channel']", $nsManager)
+if ($null -eq $channelItem) {
+    throw "Could not find channel item for channel: $channel"
+}
+
+# Update the item properties
+$channelItem.title = $tag
+$channelItem.pubDate = $pubDate
+$channelItem.SelectSingleNode("sparkle:version", $nsManager).InnerText = $version
+$channelItem.SelectSingleNode("sparkle:shortVersionString", $nsManager).InnerText = $version
+$channelItem.SelectSingleNode("sparkle:fullReleaseNotesLink", $nsManager).InnerText = "https://github.com/$repo/releases"
+
+# Set description with proper line breaks
+$descriptionNode = $channelItem.SelectSingleNode("description")
+$descriptionNode.InnerXml = "" # Clear existing content
+$cdata = $appCast.CreateCDataSection([System.IO.File]::ReadAllText($releaseNotesHtmlPath))
+$descriptionNode.AppendChild($cdata) | Out-Null
+
+# Remove existing enclosures
+$existingEnclosures = $channelItem.SelectNodes("enclosure")
+foreach ($enclosure in $existingEnclosures) {
+    $channelItem.RemoveChild($enclosure) | Out-Null
+}
+
+# Add new enclosures
+$enclosures = @(
+    @{
+        path = $x64Path
+        os   = "win-x64"
+    },
+    @{
+        path = $arm64Path
+        os   = "win-arm64"
+    }
+)
+foreach ($enclosure in $enclosures) {
+    $fileName = Split-Path $enclosure.path -Leaf
+    $url = "https://github.com/$repo/releases/download/$tag/$fileName"
+    $fileSize = (Get-Item $enclosure.path).Length
+    $signature = Get-Ed25519Signature $enclosure.path
+
+    $newEnclosure = $appCast.CreateElement("enclosure")
+    $newEnclosure.SetAttribute("url", $url)
+    $newEnclosure.SetAttribute("type", "application/x-msdos-program")
+    $newEnclosure.SetAttribute("length", $fileSize)
+
+    # Set namespaced attributes
+    $sparkleNs = $nsManager.LookupNamespace("sparkle")
+    $attrs = @{
+        "os"                 = $enclosure.os
+        "version"            = $version
+        "shortVersionString" = $version
+        "criticalUpdate"     = "false"
+        "edSignature"        = $signature # NetSparkle prefers edSignature over signature
+    }
+    foreach ($key in $attrs.Keys) {
+        $attr = $appCast.CreateAttribute("sparkle", $key, $sparkleNs)
+        $attr.Value = $attrs[$key]
+        $newEnclosure.Attributes.Append($attr) | Out-Null
+    }
+
+    $channelItem.AppendChild($newEnclosure) | Out-Null
+}
+
+# Save the updated XML. Convert CRLF to LF since CRLF seems to break NetSparkle
+$appCast.Save($outputAppCastPath)
+$content = [System.IO.File]::ReadAllText($outputAppCastPath)
+$content = $content -replace "`r`n", "`n"
+[System.IO.File]::WriteAllText($outputAppCastPath, $content)
+
+Write-Output "---- Updated appcast -----"
+Get-Content $outputAppCastPath
+Write-Output "---- End of updated appcast ----"
+Write-Output ""
+
+# Generate the signature for the appcast itself
+$appCastSignature = Get-Ed25519Signature $outputAppCastPath
+[System.IO.File]::WriteAllText($outputAppCastSignaturePath, $appCastSignature)
+Write-Output "---- Updated appcast signature -----"
+Get-Content $outputAppCastSignaturePath
+Write-Output "---- End of updated appcast signature ----"

--- a/scripts/Update-AppCast.ps1
+++ b/scripts/Update-AppCast.ps1
@@ -27,7 +27,8 @@ param (
     [string] $channel,
 
     [Parameter(Mandatory = $false)]
-    [string] $pubDate = (Get-Date).ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss +0000"),
+    [ValidatePattern("^\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} \+00:00$")]
+    [string] $pubDate = (Get-Date).ToUniversalTime().ToString("ddd, dd MMM yyyy HH:mm:ss +00:00"),
 
     [Parameter(Mandatory = $true)]
     [ValidateScript({ Test-Path $_ })]

--- a/scripts/Update-AppCast.ps1
+++ b/scripts/Update-AppCast.ps1
@@ -5,7 +5,6 @@
 #
 # Usage: Update-AppCast.ps1
 #          -tag <tag>
-#          -version <version>
 #          -channel <stable|preview>
 #          -x64Path <path>
 #          -arm64Path <path>
@@ -17,10 +16,6 @@ param (
     [Parameter(Mandatory = $true)]
     [ValidatePattern("^v\d+\.\d+\.\d+$")]
     [string] $tag,
-
-    [Parameter(Mandatory = $true)]
-    [ValidatePattern("^\d+\.\d+\.\d+$")]
-    [string] $version,
 
     [Parameter(Mandatory = $true)]
     [ValidateSet('stable', 'preview')]
@@ -56,6 +51,8 @@ param (
 $ErrorActionPreference = "Stop"
 
 $repo = "coder/coder-desktop-windows"
+
+$version = $tag.Substring(1) # remove the v prefix
 
 function Get-Ed25519Signature {
     param (


### PR DESCRIPTION
Adds an auto updater utility using NetSparkle.

Most of the UI matches the way it's done in NetSparkle for the built-in UIs (I referenced the Avalonia and WPF ones mostly), including most of the copy and implementation (incl. quirks). I did this in case we ever want to contribute this upstream. The only major difference is how I handle the release notes stuff.

For release notes, I use the `<description>` tag to generate HTML for the web view. There's a hardcoded """template""" in the source code and a copy of [sindresorhus/github-markdown-css](https://github.com/sindresorhus/github-markdown-css) in the repo that gets included as an asset in the binary. This matches what we do on macOS but diverges from the way NetSparkle does release notes rendering using `<sparkle:releaseNotesUrl>` (or something like that).

- Adds a button to the right click context menu on the tray icon for checking for updates
- Adds custom UIs for all parts of the updater
- Implements "action" notifications with a click handler into UserNotifier
- Adds Serilog output to the debug output window in VS in DEBUG builds

### TODO:

- [x] App cast generation script
- [x] Release pipeline modifications
- [x] Generate secret key and add to repo secrets
- [x] Publish initial 0.5.0 version manually
- [x] Set final security and update source related settings in NetSparkle

### Follow up:
- Integrate into the settings UI, add controls for whether it should automatically check for updates etc.

![devenv_2vdCHXcF7M](https://github.com/user-attachments/assets/24b36fd2-e37f-49cd-9a68-55e1491c7533)
![explorer_eLh2FqvWI4](https://github.com/user-attachments/assets/4f222bd0-8b00-4bc8-af77-8955cd64dc37)

Closes https://github.com/coder/coder-desktop-windows/issues/122
Closes https://github.com/coder/internal/issues/703 (thanks Blink)