### PR TITLE
fix: use custom user data dir for updater WebView2

### DIFF
--- a/App/App.csproj
+++ b/App/App.csproj
@@ -17,6 +17,8 @@
         <LangVersion>preview</LangVersion>
         <!-- We have our own implementation of main with exception handling -->
         <DefineConstants>DISABLE_XAML_GENERATED_MAIN;DISABLE_XAML_GENERATED_BREAK_ON_UNHANDLED_EXCEPTION</DefineConstants>
+        <!-- Default version for debug builds, overridden during releases -->
+        <Version>0.1.0.0</Version>
 
         <AssemblyName>Coder Desktop</AssemblyName>
         <AssemblyTitle>Coder Desktop</AssemblyTitle>


### PR DESCRIPTION
The default location was in the install directory, which is not writeable by regular users. We now store the WebView2 data directory in our AppData/Local folder.

This is what it looked like when broken:
![image](https://github.com/user-attachments/assets/f6d241d7-9341-4c70-9e7f-b8230dc5c9d4)
