### PR TITLE
chore: hide commit SHA in updater window

### DIFF
--- a/App/App.csproj
+++ b/App/App.csproj
@@ -24,6 +24,7 @@
         <Product>Coder Desktop</Product>
         <Copyright>© Coder Technologies Inc.</Copyright>
         <ApplicationIcon>coder.ico</ApplicationIcon>
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(Configuration) == 'Release'">


### PR DESCRIPTION
Prevents the commit SHA from being included in the "informational version" of the assembly, which is where NetSparkle gets the current version from.

Before:
![image](https://github.com/user-attachments/assets/b34c34d8-7ba1-4981-8d37-77d70d2cfd41)

After:
![image](https://github.com/user-attachments/assets/b1d8e5d6-3247-4a1b-9d99-65e52ef183b0)
