### PR TITLE
fix: remove dependency on iphlpsvc

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -227,10 +227,10 @@ public class Program
             RestartServiceDelayInSeconds = 30,
             ResetPeriodInDays = 1,
             PreShutdownDelay = 1000 * 60 * 3, // default
-            // This matches Tailscale's service dependencies.
+            // This matches Tailscale's service dependencies, with one omission: iphlpsvc. We do not
+            // use any of the IPv6 transition technologies provided by that service.
             DependsOn =
             [
-                new ServiceDependency("iphlpsvc"), // IP Helper
                 new ServiceDependency("netprofm"), // Network List Service
                 new ServiceDependency("WinHttpAutoProxySvc"), // WinHTTP Web Proxy Auto-Discovery Service
             ],

--- a/Tests.App/Services/SettingsManagerTest.cs
+++ b/Tests.App/Services/SettingsManagerTest.cs
@@ -2,6 +2,7 @@ using Coder.Desktop.App.Models;
 using Coder.Desktop.App.Services;
 
 namespace Coder.Desktop.Tests.App.Services;
+
 [TestFixture]
 public sealed class SettingsManagerTests
 {


### PR DESCRIPTION
Closes #160

Remove `iphlpsvc` as a dependency because we don't use the IPv6 transition technologies provided by that service.