### PR TITLE
feat: make default file and directory sync permissions configurable

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -312,6 +312,8 @@ public partial class App : Application, IDispatcherQueueManager, IDefaultNotific
         builder.AddInMemoryCollection(new Dictionary<string, string?>
         {
             [MutagenControllerConfigSection + ":MutagenExecutablePath"] = @"C:\mutagen.exe",
+            [MutagenControllerConfigSection + ":DefaultFileMode"] = "420", // 0644
+            [MutagenControllerConfigSection + ":DefaultDirectoryMode"] = "493", // 0755
 
             ["Serilog:Using:0"] = "Serilog.Sinks.File",
             ["Serilog:MinimumLevel"] = DefaultLogLevel,

--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -273,7 +273,9 @@ public class Program
 
             // Add registry values that are consumed by the App MutagenController. See App/Services/MutagenController.cs
             new RegValue(RegistryHive, AppConfigRegistryKey, "MutagenController:MutagenExecutablePath",
-                @"[INSTALLFOLDER]vpn\mutagen.exe")
+                @"[INSTALLFOLDER]vpn\mutagen.exe"),
+            new RegValue(RegistryHive, AppConfigRegistryKey, "MutagenController:DefaultFileMode", "420"),
+            new RegValue(RegistryHive, AppConfigRegistryKey, "MutagenController:DefaultDirectoryMode", "493")
         );
 
         // Note: most of this control panel info will not be visible as this


### PR DESCRIPTION
This PR introduces configurable default file and directory permissions for Mutagen sync sessions. This is particularly useful for web development workflows where standard Linux permissions (0644/0755) are required for the web server to access synchronized files.

Key changes:
- Added DefaultFileMode and DefaultDirectoryMode to MutagenControllerConfig.
- Updated MutagenController to apply these modes using PermissionsMode.Portable.