### PR TITLE
fix: show sign-in window on launch when not authenticated

### DIFF
--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -259,20 +259,44 @@ public partial class App : Application, IDispatcherQueueManager, IDefaultNotific
             _logger.LogError($"Failed to refresh sync session state {ex.Message}", ex);
         }
 
-        // If the user is not signed in, automatically show the sign-in window.
-        // This ensures new users see a clear next step instead of the app
-        // silently minimizing to the system tray.
-        var credentialModel = credentialManager.GetCachedCredentials();
-        if (credentialModel.State == CredentialState.Invalid)
+        // If the user is not signed in and we haven't shown the sign-in
+        // window before, show it automatically. This ensures new users see a
+        // clear next step on first launch instead of the app silently
+        // minimizing to the system tray. A marker file is written so the
+        // window is only shown once.
+        try
         {
-            TrayWindow?.DispatcherQueue.TryEnqueue(() =>
+            var credentialModel = credentialManager.GetCachedCredentials();
+            if (credentialModel.State == CredentialState.Invalid && !SignInPromptMarkerExists())
             {
-                var signInWindow = _services.GetRequiredService<SignInWindow>();
-                signInWindow.Activate();
-            });
+                WriteSignInPromptMarker();
+                TrayWindow?.DispatcherQueue.TryEnqueue(() =>
+                {
+                    var signInWindow = _services.GetRequiredService<SignInWindow>();
+                    signInWindow.Activate();
+                });
+            }
         }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to show sign-in window on first launch");
+        }
+
     }
 
+    private static string SignInPromptMarkerPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "CoderDesktop",
+        ".sign-in-prompt-shown");
+
+    private static bool SignInPromptMarkerExists() => File.Exists(SignInPromptMarkerPath);
+
+    private static void WriteSignInPromptMarker()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(SignInPromptMarkerPath)!);
+        File.WriteAllBytes(SignInPromptMarkerPath, Array.Empty<byte>());
+    }
+    
     public void OnActivated(object? sender, AppActivationArguments args)
     {
         switch (args.Kind)

--- a/App/App.xaml.cs
+++ b/App/App.xaml.cs
@@ -258,6 +258,19 @@ public partial class App : Application, IDispatcherQueueManager, IDefaultNotific
         {
             _logger.LogError($"Failed to refresh sync session state {ex.Message}", ex);
         }
+
+        // If the user is not signed in, automatically show the sign-in window.
+        // This ensures new users see a clear next step instead of the app
+        // silently minimizing to the system tray.
+        var credentialModel = credentialManager.GetCachedCredentials();
+        if (credentialModel.State == CredentialState.Invalid)
+        {
+            TrayWindow?.DispatcherQueue.TryEnqueue(() =>
+            {
+                var signInWindow = _services.GetRequiredService<SignInWindow>();
+                signInWindow.Activate();
+            });
+        }
     }
 
     public void OnActivated(object? sender, AppActivationArguments args)


### PR DESCRIPTION
**This is a Blink Assisted PR. However, I have gone through the changes and tested the resulting executable on a Windows VM in AWS.**

When Coder Desktop launches and the user is not signed in, the app now automatically opens the sign-in window instead of silently minimizing to the system tray. This gives new users a clear next step and confirms the app is running.

Previously, a fresh install produced no visible window or taskbar entry, requiring users to discover the system tray icon to find the sign-in prompt. This led users to believe the application failed to start.

When already authenticated, the existing behavior (going silently to the system tray) is preserved.

**Update:** To avoid being disruptive, the sign-in window is only shown once (on the first launch). Subsequent starts, including computer restarts, preserve the existing silent-to-tray behavior, even if the user still hasn't signed in. Users who are already authenticated are unaffected.

Fixes coder/coder-desktop-windows#164