### PR TITLE
fix: remove dependency on WPAD

### DIFF
--- a/Installer/Program.cs
+++ b/Installer/Program.cs
@@ -227,12 +227,12 @@ public class Program
             RestartServiceDelayInSeconds = 30,
             ResetPeriodInDays = 1,
             PreShutdownDelay = 1000 * 60 * 3, // default
-            // This matches Tailscale's service dependencies, with one omission: iphlpsvc. We do not
-            // use any of the IPv6 transition technologies provided by that service.
+            // This matches Tailscale's service dependencies, with two omissions:
+            // - iphlpsvc - We do not use any of the IPv6 transition technologies provided by that service.
+            // - WinHttpAutoProxySvc - We don't use tshttpproxy, so we don't require WPAD.
             DependsOn =
             [
                 new ServiceDependency("netprofm"), // Network List Service
-                new ServiceDependency("WinHttpAutoProxySvc"), // WinHTTP Web Proxy Auto-Discovery Service
             ],
         };
         var shortcut = new FileShortcut("Coder Desktop", "%StartMenuFolder%")


### PR DESCRIPTION
Existing Coder binary works without this dependency on the service running, tested on my own machine. It seems that the only `tailscaled` component that requires WPAD is `tshttpproxy` which we don't use.