### PR TITLE
feat: send WakeRequest to the tunnel on system resume

### DIFF
--- a/Tests.Vpn.Proto/RpcVersionTest.cs
+++ b/Tests.Vpn.Proto/RpcVersionTest.cs
@@ -41,14 +41,14 @@ public class RpcVersionTest
         IsCompatibleWithBothWays(twoOne, new RpcVersion(1, 1), Is.Null);
     }
 
-    [Test(Description = "Check feature support against the version that introduced the feature")]
-    public void SupportsFeature()
+    [Test(Description = "Compare versions with IsAtLeast")]
+    public void IsAtLeast()
     {
-        var featureVersion = new RpcVersion(1, 3);
-        Assert.That(new RpcVersion(1, 3).SupportsFeature(featureVersion), Is.True);
-        Assert.That(new RpcVersion(1, 4).SupportsFeature(featureVersion), Is.True);
-        Assert.That(new RpcVersion(1, 2).SupportsFeature(featureVersion), Is.False);
-        Assert.That(new RpcVersion(2, 3).SupportsFeature(featureVersion), Is.False);
+        var oneThree = new RpcVersion(1, 3);
+        Assert.That(oneThree.IsAtLeast(oneThree), Is.True);
+        Assert.That(new RpcVersion(1, 4).IsAtLeast(oneThree), Is.True);
+        Assert.That(new RpcVersion(2, 0).IsAtLeast(oneThree), Is.True);
+        Assert.That(new RpcVersion(1, 2).IsAtLeast(oneThree), Is.False);
     }
 }
 

--- a/Tests.Vpn.Proto/RpcVersionTest.cs
+++ b/Tests.Vpn.Proto/RpcVersionTest.cs
@@ -40,6 +40,18 @@ public class RpcVersionTest
         // 2.1 && 1.1 => null
         IsCompatibleWithBothWays(twoOne, new RpcVersion(1, 1), Is.Null);
     }
+
+    [Test(Description = "Check feature support against the version that introduced the feature")]
+    public void SupportsFeature()
+    {
+        var featureVersion = new RpcVersion(1, 3);
+        Assert.That(new RpcVersion(1, 3).SupportsFeature(featureVersion), Is.True);
+        Assert.That(new RpcVersion(1, 4).SupportsFeature(featureVersion), Is.True);
+        Assert.That(new RpcVersion(1, 2).SupportsFeature(featureVersion), Is.False);
+        // Major versions must match exactly.
+        Assert.That(new RpcVersion(2, 3).SupportsFeature(featureVersion), Is.False);
+        Assert.That(new RpcVersion(2, 4).SupportsFeature(featureVersion), Is.False);
+    }
 }
 
 [TestFixture]

--- a/Tests.Vpn.Proto/RpcVersionTest.cs
+++ b/Tests.Vpn.Proto/RpcVersionTest.cs
@@ -48,9 +48,7 @@ public class RpcVersionTest
         Assert.That(new RpcVersion(1, 3).SupportsFeature(featureVersion), Is.True);
         Assert.That(new RpcVersion(1, 4).SupportsFeature(featureVersion), Is.True);
         Assert.That(new RpcVersion(1, 2).SupportsFeature(featureVersion), Is.False);
-        // Major versions must match exactly.
         Assert.That(new RpcVersion(2, 3).SupportsFeature(featureVersion), Is.False);
-        Assert.That(new RpcVersion(2, 4).SupportsFeature(featureVersion), Is.False);
     }
 }
 

--- a/Tests.Vpn.Service/ManagerTest.cs
+++ b/Tests.Vpn.Service/ManagerTest.cs
@@ -1,0 +1,195 @@
+using Coder.Desktop.Vpn;
+using Coder.Desktop.Vpn.Proto;
+using Coder.Desktop.Vpn.Service;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Coder.Desktop.Tests.Vpn.Service;
+
+#region Fakes
+
+internal class FakeTunnelSupervisor : ITunnelSupervisor
+{
+    public RpcVersion? NegotiatedVersion { get; set; }
+
+    public List<ManagerMessage> SentRequests { get; } = [];
+    public TunnelMessage? Reply { get; set; }
+    public Exception? SendException { get; set; }
+
+    public Task StartAsync(string binPath, Speaker<ManagerMessage, TunnelMessage>.OnReceiveDelegate messageHandler,
+        Speaker<ManagerMessage, TunnelMessage>.OnErrorDelegate errorHandler, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task StopAsync(CancellationToken ct = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task SendMessage(ManagerMessage message, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<TunnelMessage> SendRequestAwaitReply(ManagerMessage message, CancellationToken ct = default)
+    {
+        SentRequests.Add(message);
+        if (SendException != null) throw SendException;
+        if (Reply == null) throw new InvalidOperationException("No reply configured on FakeTunnelSupervisor");
+        return ValueTask.FromResult(Reply);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal class FakeManagerRpc : IManagerRpc
+{
+#pragma warning disable CS0067 // The event is only subscribed to by Manager, never raised in these tests.
+    public event IManagerRpc.OnReceiveHandler? OnReceive;
+#pragma warning restore CS0067
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task BroadcastAsync(ServiceMessage message, CancellationToken ct = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}
+
+internal class FakeDownloader : IDownloader
+{
+    public Task<DownloadTask> StartDownloadAsync(HttpRequestMessage req, string destinationPath,
+        IDownloadValidator validator, CancellationToken ct = default)
+    {
+        throw new NotImplementedException();
+    }
+}
+
+internal class FakeTelemetryEnricher : ITelemetryEnricher
+{
+    public StartRequest EnrichStartRequest(StartRequest original)
+    {
+        return original;
+    }
+}
+
+#endregion
+
+[TestFixture]
+public class ManagerTest
+{
+    private static Manager NewManager(ITunnelSupervisor tunnelSupervisor)
+    {
+        return new Manager(Options.Create(new ManagerConfig()), NullLogger<Manager>.Instance, new FakeDownloader(),
+            tunnelSupervisor, new FakeManagerRpc(), new FakeTelemetryEnricher());
+    }
+
+    [Test(Description = "Send a wake request to the tunnel on system resume")]
+    [CancelAfter(30_000)]
+    public async Task HandleSystemResumeSendsWakeRequest(CancellationToken ct)
+    {
+        var tunnelSupervisor = new FakeTunnelSupervisor
+        {
+            NegotiatedVersion = new RpcVersion(1, 3),
+            Reply = new TunnelMessage
+            {
+                Wake = new WakeResponse
+                {
+                    Success = true,
+                },
+            },
+        };
+        using var manager = NewManager(tunnelSupervisor);
+
+        await manager.HandleSystemResume(ct);
+
+        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
+        Assert.That(tunnelSupervisor.SentRequests[0].MsgCase, Is.EqualTo(ManagerMessage.MsgOneofCase.Wake));
+    }
+
+    [Test(Description = "Skip the wake request when the tunnel is not running")]
+    [CancelAfter(30_000)]
+    public async Task HandleSystemResumeSkipsWhenTunnelNotRunning(CancellationToken ct)
+    {
+        var tunnelSupervisor = new FakeTunnelSupervisor
+        {
+            NegotiatedVersion = null,
+        };
+        using var manager = NewManager(tunnelSupervisor);
+
+        await manager.HandleSystemResume(ct);
+
+        Assert.That(tunnelSupervisor.SentRequests, Is.Empty);
+    }
+
+    [Test(Description = "Skip the wake request when the negotiated version does not support it")]
+    [CancelAfter(30_000)]
+    public async Task HandleSystemResumeSkipsWhenVersionTooOld(CancellationToken ct)
+    {
+        var tunnelSupervisor = new FakeTunnelSupervisor
+        {
+            NegotiatedVersion = new RpcVersion(1, 2),
+        };
+        using var manager = NewManager(tunnelSupervisor);
+
+        await manager.HandleSystemResume(ct);
+
+        Assert.That(tunnelSupervisor.SentRequests, Is.Empty);
+    }
+
+    [Test(Description = "Ignore an unexpected reply message type to a wake request")]
+    [CancelAfter(30_000)]
+    public async Task HandleSystemResumeIgnoresUnexpectedReply(CancellationToken ct)
+    {
+        var tunnelSupervisor = new FakeTunnelSupervisor
+        {
+            NegotiatedVersion = new RpcVersion(1, 3),
+            Reply = new TunnelMessage
+            {
+                Stop = new StopResponse(),
+            },
+        };
+        using var manager = NewManager(tunnelSupervisor);
+
+        // HandleSystemResume must not throw when the tunnel replies with an
+        // unexpected message type.
+        await manager.HandleSystemResume(ct);
+
+        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
+    }
+
+    [Test(Description = "Ignore a wake request send failure without affecting the tunnel")]
+    [CancelAfter(30_000)]
+    public async Task HandleSystemResumeIgnoresSendFailure(CancellationToken ct)
+    {
+        var tunnelSupervisor = new FakeTunnelSupervisor
+        {
+            NegotiatedVersion = new RpcVersion(1, 3),
+            SendException = new InvalidOperationException("TunnelSupervisor is not running"),
+        };
+        using var manager = NewManager(tunnelSupervisor);
+
+        // HandleSystemResume must not throw when sending the wake request
+        // fails.
+        await manager.HandleSystemResume(ct);
+
+        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
+    }
+}

--- a/Tests.Vpn.Service/ManagerTest.cs
+++ b/Tests.Vpn.Service/ManagerTest.cs
@@ -11,10 +11,17 @@ namespace Coder.Desktop.Tests.Vpn.Service;
 internal class FakeTunnelSupervisor : ITunnelSupervisor
 {
     public RpcVersion? NegotiatedVersion { get; set; }
-
-    public List<ManagerMessage> SentRequests { get; } = [];
-    public TunnelMessage? Reply { get; set; }
     public Exception? SendException { get; set; }
+    public List<ManagerMessage> SentRequests { get; } = [];
+    public TaskCompletionSource Sent { get; } = new();
+
+    public ValueTask<TunnelMessage> SendRequestAwaitReply(ManagerMessage message, CancellationToken ct = default)
+    {
+        SentRequests.Add(message);
+        Sent.TrySetResult();
+        if (SendException != null) throw SendException;
+        return ValueTask.FromResult(new TunnelMessage { Wake = new WakeResponse() });
+    }
 
     public Task StartAsync(string binPath, Speaker<ManagerMessage, TunnelMessage>.OnReceiveDelegate messageHandler,
         Speaker<ManagerMessage, TunnelMessage>.OnErrorDelegate errorHandler, CancellationToken ct = default)
@@ -32,23 +39,29 @@ internal class FakeTunnelSupervisor : ITunnelSupervisor
         throw new NotImplementedException();
     }
 
-    public ValueTask<TunnelMessage> SendRequestAwaitReply(ManagerMessage message, CancellationToken ct = default)
-    {
-        SentRequests.Add(message);
-        if (SendException != null) throw SendException;
-        if (Reply == null) throw new InvalidOperationException("No reply configured on FakeTunnelSupervisor");
-        return ValueTask.FromResult(Reply);
-    }
-
     public ValueTask DisposeAsync()
     {
         return ValueTask.CompletedTask;
     }
 }
 
+internal class FakeSystemResumeMonitor : ISystemResumeMonitor
+{
+    public event EventHandler? Resumed;
+
+    public void Raise()
+    {
+        Resumed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void Dispose()
+    {
+    }
+}
+
 internal class FakeManagerRpc : IManagerRpc
 {
-#pragma warning disable CS0067 // The event is only subscribed to by Manager, never raised in these tests.
+#pragma warning disable CS0067 // Never raised in tests.
     public event IManagerRpc.OnReceiveHandler? OnReceive;
 #pragma warning restore CS0067
 
@@ -95,101 +108,56 @@ internal class FakeTelemetryEnricher : ITelemetryEnricher
 [TestFixture]
 public class ManagerTest
 {
-    private static Manager NewManager(ITunnelSupervisor tunnelSupervisor)
+    private static Manager NewManager(ITunnelSupervisor tunnelSupervisor, ISystemResumeMonitor? resumeMonitor = null)
     {
         return new Manager(Options.Create(new ManagerConfig()), NullLogger<Manager>.Instance, new FakeDownloader(),
-            tunnelSupervisor, new FakeManagerRpc(), new FakeTelemetryEnricher());
+            tunnelSupervisor, new FakeManagerRpc(), new FakeTelemetryEnricher(),
+            resumeMonitor ?? new FakeSystemResumeMonitor());
     }
 
     [Test(Description = "Send a wake request to the tunnel on system resume")]
     [CancelAfter(30_000)]
-    public async Task HandleSystemResumeSendsWakeRequest(CancellationToken ct)
+    public async Task SendsWakeRequestOnResume(CancellationToken ct)
     {
-        var tunnelSupervisor = new FakeTunnelSupervisor
-        {
-            NegotiatedVersion = new RpcVersion(1, 3),
-            Reply = new TunnelMessage
-            {
-                Wake = new WakeResponse
-                {
-                    Success = true,
-                },
-            },
-        };
-        using var manager = NewManager(tunnelSupervisor);
+        var supervisor = new FakeTunnelSupervisor { NegotiatedVersion = new RpcVersion(1, 3) };
+        var monitor = new FakeSystemResumeMonitor();
+        using var manager = NewManager(supervisor, monitor);
 
-        await manager.HandleSystemResume(ct);
+        monitor.Raise();
 
-        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
-        Assert.That(tunnelSupervisor.SentRequests[0].MsgCase, Is.EqualTo(ManagerMessage.MsgOneofCase.Wake));
+        await supervisor.Sent.Task.WaitAsync(ct);
+        Assert.That(supervisor.SentRequests[0].MsgCase, Is.EqualTo(ManagerMessage.MsgOneofCase.Wake));
     }
 
-    [Test(Description = "Skip the wake request when the tunnel is not running")]
+    [TestCase(null, Description = "Tunnel not running")]
+    [TestCase("1.2", Description = "Version does not support wake")]
     [CancelAfter(30_000)]
-    public async Task HandleSystemResumeSkipsWhenTunnelNotRunning(CancellationToken ct)
+    public async Task SkipsWakeRequestWhenUnsupported(string? version, CancellationToken ct)
     {
-        var tunnelSupervisor = new FakeTunnelSupervisor
+        var supervisor = new FakeTunnelSupervisor
         {
-            NegotiatedVersion = null,
+            NegotiatedVersion = version == null ? null : RpcVersion.Parse(version),
         };
-        using var manager = NewManager(tunnelSupervisor);
+        using var manager = NewManager(supervisor);
 
-        await manager.HandleSystemResume(ct);
+        await manager.SendWakeRequest(ct);
 
-        Assert.That(tunnelSupervisor.SentRequests, Is.Empty);
+        Assert.That(supervisor.SentRequests, Is.Empty);
     }
 
-    [Test(Description = "Skip the wake request when the negotiated version does not support it")]
+    [Test(Description = "Wake request failures are swallowed")]
     [CancelAfter(30_000)]
-    public async Task HandleSystemResumeSkipsWhenVersionTooOld(CancellationToken ct)
+    public async Task IgnoresWakeRequestFailure(CancellationToken ct)
     {
-        var tunnelSupervisor = new FakeTunnelSupervisor
-        {
-            NegotiatedVersion = new RpcVersion(1, 2),
-        };
-        using var manager = NewManager(tunnelSupervisor);
-
-        await manager.HandleSystemResume(ct);
-
-        Assert.That(tunnelSupervisor.SentRequests, Is.Empty);
-    }
-
-    [Test(Description = "Ignore an unexpected reply message type to a wake request")]
-    [CancelAfter(30_000)]
-    public async Task HandleSystemResumeIgnoresUnexpectedReply(CancellationToken ct)
-    {
-        var tunnelSupervisor = new FakeTunnelSupervisor
-        {
-            NegotiatedVersion = new RpcVersion(1, 3),
-            Reply = new TunnelMessage
-            {
-                Stop = new StopResponse(),
-            },
-        };
-        using var manager = NewManager(tunnelSupervisor);
-
-        // HandleSystemResume must not throw when the tunnel replies with an
-        // unexpected message type.
-        await manager.HandleSystemResume(ct);
-
-        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
-    }
-
-    [Test(Description = "Ignore a wake request send failure without affecting the tunnel")]
-    [CancelAfter(30_000)]
-    public async Task HandleSystemResumeIgnoresSendFailure(CancellationToken ct)
-    {
-        var tunnelSupervisor = new FakeTunnelSupervisor
+        var supervisor = new FakeTunnelSupervisor
         {
             NegotiatedVersion = new RpcVersion(1, 3),
             SendException = new InvalidOperationException("TunnelSupervisor is not running"),
         };
-        using var manager = NewManager(tunnelSupervisor);
+        using var manager = NewManager(supervisor);
 
-        // HandleSystemResume must not throw when sending the wake request
-        // fails.
-        await manager.HandleSystemResume(ct);
+        await manager.SendWakeRequest(ct);
 
-        Assert.That(tunnelSupervisor.SentRequests, Has.Count.EqualTo(1));
+        Assert.That(supervisor.SentRequests, Has.Count.EqualTo(1));
     }
 }

--- a/Tests.Vpn.Service/ManagerTest.cs
+++ b/Tests.Vpn.Service/ManagerTest.cs
@@ -6,53 +6,39 @@ using Microsoft.Extensions.Options;
 
 namespace Coder.Desktop.Tests.Vpn.Service;
 
-#region Fakes
-
-internal class FakeTunnelSupervisor : ITunnelSupervisor
+internal class FakeTunnelSupervisor(RpcVersion? negotiatedVersion, Exception? sendException = null)
+    : ITunnelSupervisor
 {
-    public RpcVersion? NegotiatedVersion { get; set; }
-    public Exception? SendException { get; set; }
     public List<ManagerMessage> SentRequests { get; } = [];
     public TaskCompletionSource Sent { get; } = new();
+
+    public RpcVersion? NegotiatedVersion => negotiatedVersion;
 
     public ValueTask<TunnelMessage> SendRequestAwaitReply(ManagerMessage message, CancellationToken ct = default)
     {
         SentRequests.Add(message);
         Sent.TrySetResult();
-        if (SendException != null) throw SendException;
+        if (sendException != null) throw sendException;
         return ValueTask.FromResult(new TunnelMessage { Wake = new WakeResponse() });
     }
 
     public Task StartAsync(string binPath, Speaker<ManagerMessage, TunnelMessage>.OnReceiveDelegate messageHandler,
         Speaker<ManagerMessage, TunnelMessage>.OnErrorDelegate errorHandler, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 
-    public Task StopAsync(CancellationToken ct = default)
-    {
-        return Task.CompletedTask;
-    }
+    public Task StopAsync(CancellationToken ct = default) => Task.CompletedTask;
 
     public Task SendMessage(ManagerMessage message, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 
-    public ValueTask DisposeAsync()
-    {
-        return ValueTask.CompletedTask;
-    }
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }
 
 internal class FakeSystemResumeMonitor : ISystemResumeMonitor
 {
     public event EventHandler? Resumed;
 
-    public void Raise()
-    {
-        Resumed?.Invoke(this, EventArgs.Empty);
-    }
+    public void Raise() => Resumed?.Invoke(this, EventArgs.Empty);
 
     public void Dispose()
     {
@@ -65,67 +51,43 @@ internal class FakeManagerRpc : IManagerRpc
     public event IManagerRpc.OnReceiveHandler? OnReceive;
 #pragma warning restore CS0067
 
-    public Task StopAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
-
-    public Task ExecuteAsync(CancellationToken stoppingToken)
-    {
-        return Task.CompletedTask;
-    }
-
-    public Task BroadcastAsync(ServiceMessage message, CancellationToken ct = default)
-    {
-        return Task.CompletedTask;
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        return ValueTask.CompletedTask;
-    }
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public Task ExecuteAsync(CancellationToken stoppingToken) => Task.CompletedTask;
+    public Task BroadcastAsync(ServiceMessage message, CancellationToken ct = default) => Task.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }
 
 internal class FakeDownloader : IDownloader
 {
     public Task<DownloadTask> StartDownloadAsync(HttpRequestMessage req, string destinationPath,
         IDownloadValidator validator, CancellationToken ct = default)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 internal class FakeTelemetryEnricher : ITelemetryEnricher
 {
-    public StartRequest EnrichStartRequest(StartRequest original)
-    {
-        return original;
-    }
+    public StartRequest EnrichStartRequest(StartRequest original) => original;
 }
-
-#endregion
 
 [TestFixture]
 public class ManagerTest
 {
     private static Manager NewManager(ITunnelSupervisor tunnelSupervisor, ISystemResumeMonitor? resumeMonitor = null)
-    {
-        return new Manager(Options.Create(new ManagerConfig()), NullLogger<Manager>.Instance, new FakeDownloader(),
+        => new(Options.Create(new ManagerConfig()), NullLogger<Manager>.Instance, new FakeDownloader(),
             tunnelSupervisor, new FakeManagerRpc(), new FakeTelemetryEnricher(),
             resumeMonitor ?? new FakeSystemResumeMonitor());
-    }
 
     [Test(Description = "Send a wake request to the tunnel on system resume")]
     [CancelAfter(30_000)]
     public async Task SendsWakeRequestOnResume(CancellationToken ct)
     {
-        var supervisor = new FakeTunnelSupervisor { NegotiatedVersion = new RpcVersion(1, 3) };
+        var supervisor = new FakeTunnelSupervisor(new RpcVersion(1, 3));
         var monitor = new FakeSystemResumeMonitor();
         using var manager = NewManager(supervisor, monitor);
 
         monitor.Raise();
-
         await supervisor.Sent.Task.WaitAsync(ct);
+
         Assert.That(supervisor.SentRequests[0].MsgCase, Is.EqualTo(ManagerMessage.MsgOneofCase.Wake));
     }
 
@@ -134,10 +96,7 @@ public class ManagerTest
     [CancelAfter(30_000)]
     public async Task SkipsWakeRequestWhenUnsupported(string? version, CancellationToken ct)
     {
-        var supervisor = new FakeTunnelSupervisor
-        {
-            NegotiatedVersion = version == null ? null : RpcVersion.Parse(version),
-        };
+        var supervisor = new FakeTunnelSupervisor(version == null ? null : RpcVersion.Parse(version));
         using var manager = NewManager(supervisor);
 
         await manager.SendWakeRequest(ct);
@@ -149,11 +108,7 @@ public class ManagerTest
     [CancelAfter(30_000)]
     public async Task IgnoresWakeRequestFailure(CancellationToken ct)
     {
-        var supervisor = new FakeTunnelSupervisor
-        {
-            NegotiatedVersion = new RpcVersion(1, 3),
-            SendException = new InvalidOperationException("TunnelSupervisor is not running"),
-        };
+        var supervisor = new FakeTunnelSupervisor(new RpcVersion(1, 3), new InvalidOperationException("not running"));
         using var manager = NewManager(supervisor);
 
         await manager.SendWakeRequest(ct);

--- a/Tests.Vpn.Service/packages.lock.json
+++ b/Tests.Vpn.Service/packages.lock.json
@@ -379,6 +379,11 @@
           "Newtonsoft.Json": "13.0.1"
         }
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "kHgtAkXhNEP8oGuAVe3Q5admxsdMlSdWE2rXcA9FfeGDZJQawPccmZgnOswgW3ugUPSJt7VH+TMQPz65mnhGSQ=="
+      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.1",
@@ -513,6 +518,7 @@
           "Microsoft.Extensions.Hosting.WindowsServices": "[9.0.4, )",
           "Microsoft.Extensions.Options.DataAnnotations": "[9.0.4, )",
           "Microsoft.Security.Extensions": "[1.3.0, )",
+          "Microsoft.Win32.SystemEvents": "[9.0.4, )",
           "Semver": "[3.0.0, )",
           "Serilog.Extensions.Hosting": "[9.0.0, )",
           "Serilog.Settings.Configuration": "[9.0.0, )",

--- a/Tests.Vpn/SpeakerTest.cs
+++ b/Tests.Vpn/SpeakerTest.cs
@@ -172,25 +172,10 @@ public class SpeakerTest
         await using var speaker2 = new Speaker<TunnelMessage, ManagerMessage>(stream2);
 
         Assert.That(speaker1.NegotiatedVersion, Is.Null);
-        Assert.That(speaker2.NegotiatedVersion, Is.Null);
-
         await Task.WhenAll(speaker1.StartAsync(ct), speaker2.StartAsync(ct));
 
         Assert.That(speaker1.NegotiatedVersion, Is.EqualTo(RpcVersion.Current));
         Assert.That(speaker2.NegotiatedVersion, Is.EqualTo(RpcVersion.Current));
-    }
-
-    [Test(Description = "Negotiated version is the lower version of an older peer")]
-    [CancelAfter(30_000)]
-    public async Task NegotiatedVersionOlderPeer(CancellationToken ct)
-    {
-        var (stream1, stream2) = BidirectionalPipe.NewInMemory();
-        await using var speaker1 = new Speaker<ManagerMessage, TunnelMessage>(stream1);
-
-        await stream2.WriteAsync(Encoding.UTF8.GetBytes("codervpn tunnel 1.2\n"), ct);
-        await speaker1.StartAsync(ct);
-
-        Assert.That(speaker1.NegotiatedVersion, Is.EqualTo(new RpcVersion(1, 2)));
     }
 
     [Test(Description = "Encounter a write error during handshake")]

--- a/Tests.Vpn/SpeakerTest.cs
+++ b/Tests.Vpn/SpeakerTest.cs
@@ -163,6 +163,36 @@ public class SpeakerTest
         Assert.That(reply.Message.Start.Success, Is.True);
     }
 
+    [Test(Description = "Negotiated version is exposed after a successful handshake")]
+    [CancelAfter(30_000)]
+    public async Task NegotiatedVersion(CancellationToken ct)
+    {
+        var (stream1, stream2) = BidirectionalPipe.NewInMemory();
+        await using var speaker1 = new Speaker<ManagerMessage, TunnelMessage>(stream1);
+        await using var speaker2 = new Speaker<TunnelMessage, ManagerMessage>(stream2);
+
+        Assert.That(speaker1.NegotiatedVersion, Is.Null);
+        Assert.That(speaker2.NegotiatedVersion, Is.Null);
+
+        await Task.WhenAll(speaker1.StartAsync(ct), speaker2.StartAsync(ct));
+
+        Assert.That(speaker1.NegotiatedVersion, Is.EqualTo(RpcVersion.Current));
+        Assert.That(speaker2.NegotiatedVersion, Is.EqualTo(RpcVersion.Current));
+    }
+
+    [Test(Description = "Negotiated version is the lower version of an older peer")]
+    [CancelAfter(30_000)]
+    public async Task NegotiatedVersionOlderPeer(CancellationToken ct)
+    {
+        var (stream1, stream2) = BidirectionalPipe.NewInMemory();
+        await using var speaker1 = new Speaker<ManagerMessage, TunnelMessage>(stream1);
+
+        await stream2.WriteAsync(Encoding.UTF8.GetBytes("codervpn tunnel 1.2\n"), ct);
+        await speaker1.StartAsync(ct);
+
+        Assert.That(speaker1.NegotiatedVersion, Is.EqualTo(new RpcVersion(1, 2)));
+    }
+
     [Test(Description = "Encounter a write error during handshake")]
     [CancelAfter(30_000)]
     public async Task WriteError(CancellationToken ct)

--- a/Vpn.Proto/RpcVersion.cs
+++ b/Vpn.Proto/RpcVersion.cs
@@ -64,12 +64,11 @@ public class RpcVersion
     }
 
     /// <summary>
-    ///     Returns true if a peer with this version supports a feature introduced in the given version. Major
-    ///     versions must match exactly.
+    ///     Returns true if this version is equal to or newer than the other version.
     /// </summary>
-    public bool SupportsFeature(RpcVersion featureVersion)
+    public bool IsAtLeast(RpcVersion other)
     {
-        return Major == featureVersion.Major && Minor >= featureVersion.Minor;
+        return Major > other.Major || (Major == other.Major && Minor >= other.Minor);
     }
 
     #region RpcVersion Equality

--- a/Vpn.Proto/RpcVersion.cs
+++ b/Vpn.Proto/RpcVersion.cs
@@ -5,7 +5,8 @@ namespace Coder.Desktop.Vpn.Proto;
 /// </summary>
 public class RpcVersion
 {
-    public static readonly RpcVersion Current = new(1, 1);
+    // 1.3 adds WakeRequest and WakeResponse.
+    public static readonly RpcVersion Current = new(1, 3);
 
     public ulong Major { get; }
     public ulong Minor { get; }
@@ -60,6 +61,18 @@ public class RpcVersion
 
         // The lowest minor version from the two versions should be returned.
         return Minor < other.Minor ? this : other;
+    }
+
+    /// <summary>
+    ///     Returns true if a peer that negotiated this version supports a feature introduced in the given version.
+    ///     The major versions must match exactly, and this version's minor version must be at least the feature
+    ///     version's minor version.
+    /// </summary>
+    /// <param name="featureVersion">Version that introduced the feature</param>
+    /// <returns>Whether the feature is supported</returns>
+    public bool SupportsFeature(RpcVersion featureVersion)
+    {
+        return Major == featureVersion.Major && Minor >= featureVersion.Minor;
     }
 
     #region RpcVersion Equality

--- a/Vpn.Proto/RpcVersion.cs
+++ b/Vpn.Proto/RpcVersion.cs
@@ -64,12 +64,9 @@ public class RpcVersion
     }
 
     /// <summary>
-    ///     Returns true if a peer that negotiated this version supports a feature introduced in the given version.
-    ///     The major versions must match exactly, and this version's minor version must be at least the feature
-    ///     version's minor version.
+    ///     Returns true if a peer with this version supports a feature introduced in the given version. Major
+    ///     versions must match exactly.
     /// </summary>
-    /// <param name="featureVersion">Version that introduced the feature</param>
-    /// <returns>Whether the feature is supported</returns>
     public bool SupportsFeature(RpcVersion featureVersion)
     {
         return Major == featureVersion.Major && Minor >= featureVersion.Minor;

--- a/Vpn.Proto/vpn.proto
+++ b/Vpn.Proto/vpn.proto
@@ -297,6 +297,4 @@ message Status {
 // tunnel uses this as a hint to rediscover network paths.
 message WakeRequest {}
 
-message WakeResponse {
-	bool success = 1;
-}
+message WakeResponse {}

--- a/Vpn.Proto/vpn.proto
+++ b/Vpn.Proto/vpn.proto
@@ -30,6 +30,7 @@ message ManagerMessage {
 		NetworkSettingsResponse network_settings = 3;
 		StartRequest start = 4;
 		StopRequest stop = 5;
+		WakeRequest wake = 6;
 	}
 }
 
@@ -42,6 +43,7 @@ message TunnelMessage {
 		NetworkSettingsRequest network_settings = 4;
 		StartResponse start = 5;
 		StopResponse stop = 6;
+		WakeResponse wake = 7;
 	}
 }
 
@@ -289,4 +291,12 @@ message Status {
 	// should replace their current peer state. Only the Upserted fields will
 	// be populated.
 	PeerUpdate peer_update = 3;
+}
+
+// WakeRequest is sent by the manager after the system wakes from sleep. The
+// tunnel uses this as a hint to rediscover network paths.
+message WakeRequest {}
+
+message WakeResponse {
+	bool success = 1;
 }

--- a/Vpn.Service/Manager.cs
+++ b/Vpn.Service/Manager.cs
@@ -19,8 +19,6 @@ public enum TunnelStatus
 public interface IManager : IDisposable
 {
     public Task StopAsync(CancellationToken ct = default);
-
-    public Task HandleSystemResume(CancellationToken ct = default);
 }
 
 /// <summary>
@@ -28,8 +26,7 @@ public interface IManager : IDisposable
 /// </summary>
 public class Manager : IManager
 {
-    // WakeMinimumTunnelRpcVersion is the lowest RPC version negotiated with
-    // the tunnel that supports WakeRequest messages.
+    // Minimum tunnel RPC version that supports WakeRequest.
     private static readonly RpcVersion WakeMinimumTunnelRpcVersion = new(1, 3);
     private static readonly TimeSpan WakeReplyTimeout = TimeSpan.FromSeconds(5);
 
@@ -39,6 +36,7 @@ public class Manager : IManager
     private readonly ITunnelSupervisor _tunnelSupervisor;
     private readonly IManagerRpc _managerRpc;
     private readonly ITelemetryEnricher _telemetryEnricher;
+    private readonly ISystemResumeMonitor _systemResumeMonitor;
 
     private volatile TunnelStatus _status = TunnelStatus.Stopped;
 
@@ -54,7 +52,8 @@ public class Manager : IManager
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public Manager(IOptions<ManagerConfig> config, ILogger<Manager> logger, IDownloader downloader,
-        ITunnelSupervisor tunnelSupervisor, IManagerRpc managerRpc, ITelemetryEnricher telemetryEnricher)
+        ITunnelSupervisor tunnelSupervisor, IManagerRpc managerRpc, ITelemetryEnricher telemetryEnricher,
+        ISystemResumeMonitor systemResumeMonitor)
     {
         _config = config.Value;
         _logger = logger;
@@ -63,10 +62,13 @@ public class Manager : IManager
         _managerRpc = managerRpc;
         _managerRpc.OnReceive += HandleClientRpcMessage;
         _telemetryEnricher = telemetryEnricher;
+        _systemResumeMonitor = systemResumeMonitor;
+        _systemResumeMonitor.Resumed += HandleSystemResumed;
     }
 
     public void Dispose()
     {
+        _systemResumeMonitor.Resumed -= HandleSystemResumed;
         _managerRpc.OnReceive -= HandleClientRpcMessage;
         GC.SuppressFinalize(this);
     }
@@ -77,32 +79,29 @@ public class Manager : IManager
         await BroadcastStatus(null, ct);
     }
 
+    private void HandleSystemResumed(object? sender, EventArgs e)
+    {
+        // Runs on the SystemEvents broadcast thread, so send in the background.
+        _ = SendWakeRequest();
+    }
+
     /// <summary>
-    ///     Sends a WakeRequest to the tunnel so it re-discovers network paths. After the system resumes from sleep,
-    ///     the tunnel can be unusable for several minutes because a short sleep on the same network often produces no
-    ///     link-change event that would otherwise trigger recovery. The request is a hint only; failures are logged
-    ///     and never affect the running tunnel.
+    ///     Sends a WakeRequest to the tunnel so it re-discovers network paths after a system resume. Failures are
+    ///     logged and never affect the running tunnel.
     /// </summary>
-    /// <param name="ct">Cancellation token</param>
-    public async Task HandleSystemResume(CancellationToken ct = default)
+    public async Task SendWakeRequest(CancellationToken ct = default)
     {
         var version = _tunnelSupervisor.NegotiatedVersion;
-        if (version is null)
+        if (version is null || !version.SupportsFeature(WakeMinimumTunnelRpcVersion))
         {
-            _logger.LogDebug("Skipping wake request, tunnel is not running");
-            return;
-        }
-
-        if (!version.SupportsFeature(WakeMinimumTunnelRpcVersion))
-        {
-            _logger.LogDebug(
-                "Skipping wake request, negotiated tunnel RPC version {Version} is older than {MinimumVersion}",
-                version, WakeMinimumTunnelRpcVersion);
+            _logger.LogDebug("Skipping wake request, tunnel is not running or version {Version} does not support it",
+                version);
             return;
         }
 
         try
         {
+            _logger.LogInformation("Sending wake request to tunnel after system resume");
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(WakeReplyTimeout);
             var reply = await _tunnelSupervisor.SendRequestAwaitReply(new ManagerMessage
@@ -112,10 +111,6 @@ public class Manager : IManager
             if (reply.MsgCase != TunnelMessage.MsgOneofCase.Wake)
                 _logger.LogWarning("Tunnel replied to wake request with unexpected message type {MessageType}",
                     reply.MsgCase);
-            else if (!reply.Wake.Success)
-                _logger.LogWarning("Tunnel failed to handle wake request");
-            else
-                _logger.LogDebug("Tunnel handled wake request successfully");
         }
         catch (Exception e)
         {

--- a/Vpn.Service/Manager.cs
+++ b/Vpn.Service/Manager.cs
@@ -81,7 +81,8 @@ public class Manager : IManager
 
     private void HandleSystemResumed(object? sender, EventArgs e)
     {
-        // Runs on the SystemEvents broadcast thread, so send in the background.
+        // Fire-and-forget is safe: SendWakeRequest logs and swallows all
+        // failures, and must not block the SystemEvents broadcast thread.
         _ = SendWakeRequest();
     }
 
@@ -91,16 +92,16 @@ public class Manager : IManager
     /// </summary>
     public async Task SendWakeRequest(CancellationToken ct = default)
     {
-        var version = _tunnelSupervisor.NegotiatedVersion;
-        if (version is null || !version.IsAtLeast(WakeMinimumTunnelRpcVersion))
-        {
-            _logger.LogDebug("Skipping wake request, tunnel is not running or version {Version} does not support it",
-                version);
-            return;
-        }
-
         try
         {
+            var version = _tunnelSupervisor.NegotiatedVersion;
+            if (version is null || !version.IsAtLeast(WakeMinimumTunnelRpcVersion))
+            {
+                _logger.LogDebug(
+                    "Skipping wake request, tunnel is not running or version {Version} does not support it", version);
+                return;
+            }
+
             _logger.LogInformation("Sending wake request to tunnel after system resume");
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(WakeReplyTimeout);

--- a/Vpn.Service/Manager.cs
+++ b/Vpn.Service/Manager.cs
@@ -92,7 +92,7 @@ public class Manager : IManager
     public async Task SendWakeRequest(CancellationToken ct = default)
     {
         var version = _tunnelSupervisor.NegotiatedVersion;
-        if (version is null || !version.SupportsFeature(WakeMinimumTunnelRpcVersion))
+        if (version is null || !version.IsAtLeast(WakeMinimumTunnelRpcVersion))
         {
             _logger.LogDebug("Skipping wake request, tunnel is not running or version {Version} does not support it",
                 version);

--- a/Vpn.Service/Manager.cs
+++ b/Vpn.Service/Manager.cs
@@ -19,6 +19,8 @@ public enum TunnelStatus
 public interface IManager : IDisposable
 {
     public Task StopAsync(CancellationToken ct = default);
+
+    public Task HandleSystemResume(CancellationToken ct = default);
 }
 
 /// <summary>
@@ -26,6 +28,11 @@ public interface IManager : IDisposable
 /// </summary>
 public class Manager : IManager
 {
+    // WakeMinimumTunnelRpcVersion is the lowest RPC version negotiated with
+    // the tunnel that supports WakeRequest messages.
+    private static readonly RpcVersion WakeMinimumTunnelRpcVersion = new(1, 3);
+    private static readonly TimeSpan WakeReplyTimeout = TimeSpan.FromSeconds(5);
+
     private readonly ManagerConfig _config;
     private readonly IDownloader _downloader;
     private readonly ILogger<Manager> _logger;
@@ -68,6 +75,52 @@ public class Manager : IManager
     {
         await _tunnelSupervisor.StopAsync(ct);
         await BroadcastStatus(null, ct);
+    }
+
+    /// <summary>
+    ///     Sends a WakeRequest to the tunnel so it re-discovers network paths. After the system resumes from sleep,
+    ///     the tunnel can be unusable for several minutes because a short sleep on the same network often produces no
+    ///     link-change event that would otherwise trigger recovery. The request is a hint only; failures are logged
+    ///     and never affect the running tunnel.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    public async Task HandleSystemResume(CancellationToken ct = default)
+    {
+        var version = _tunnelSupervisor.NegotiatedVersion;
+        if (version is null)
+        {
+            _logger.LogDebug("Skipping wake request, tunnel is not running");
+            return;
+        }
+
+        if (!version.SupportsFeature(WakeMinimumTunnelRpcVersion))
+        {
+            _logger.LogDebug(
+                "Skipping wake request, negotiated tunnel RPC version {Version} is older than {MinimumVersion}",
+                version, WakeMinimumTunnelRpcVersion);
+            return;
+        }
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(WakeReplyTimeout);
+            var reply = await _tunnelSupervisor.SendRequestAwaitReply(new ManagerMessage
+            {
+                Wake = new WakeRequest(),
+            }, cts.Token);
+            if (reply.MsgCase != TunnelMessage.MsgOneofCase.Wake)
+                _logger.LogWarning("Tunnel replied to wake request with unexpected message type {MessageType}",
+                    reply.MsgCase);
+            else if (!reply.Wake.Success)
+                _logger.LogWarning("Tunnel failed to handle wake request");
+            else
+                _logger.LogDebug("Tunnel handled wake request successfully");
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "Failed to send wake request to tunnel");
+        }
     }
 
     /// <summary>

--- a/Vpn.Service/Program.cs
+++ b/Vpn.Service/Program.cs
@@ -85,6 +85,7 @@ public static class Program
         // Services
         builder.Services.AddHostedService<ManagerService>();
         builder.Services.AddHostedService<ManagerRpcService>();
+        builder.Services.AddHostedService<SystemResumeMonitor>();
 
         // Either run as a Windows service or a console application
         if (!Environment.UserInteractive)

--- a/Vpn.Service/Program.cs
+++ b/Vpn.Service/Program.cs
@@ -81,11 +81,11 @@ public static class Program
         builder.Services.AddSingleton<IManagerRpc, ManagerRpc>();
         builder.Services.AddSingleton<IManager, Manager>();
         builder.Services.AddSingleton<ITelemetryEnricher, TelemetryEnricher>();
+        builder.Services.AddSingleton<ISystemResumeMonitor, SystemResumeMonitor>();
 
         // Services
         builder.Services.AddHostedService<ManagerService>();
         builder.Services.AddHostedService<ManagerRpcService>();
-        builder.Services.AddHostedService<SystemResumeMonitor>();
 
         // Either run as a Windows service or a console application
         if (!Environment.UserInteractive)

--- a/Vpn.Service/SystemResumeMonitor.cs
+++ b/Vpn.Service/SystemResumeMonitor.cs
@@ -1,46 +1,32 @@
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Win32;
 
 namespace Coder.Desktop.Vpn.Service;
 
-/// <summary>
-///     Watches for the system resuming from sleep and notifies the manager so it can prompt the tunnel to re-discover
-///     network paths.
-/// </summary>
-public class SystemResumeMonitor : IHostedService
+public interface ISystemResumeMonitor : IDisposable
 {
-    private readonly ILogger<SystemResumeMonitor> _logger;
-    private readonly IManager _manager;
+    /// <summary>
+    ///     Raised when the system resumes from sleep.
+    /// </summary>
+    event EventHandler? Resumed;
+}
 
-    // ReSharper disable once ConvertToPrimaryConstructor
-    public SystemResumeMonitor(ILogger<SystemResumeMonitor> logger, IManager manager)
-    {
-        _logger = logger;
-        _manager = manager;
-    }
+public class SystemResumeMonitor : ISystemResumeMonitor
+{
+    public event EventHandler? Resumed;
 
-    public Task StartAsync(CancellationToken ct)
+    public SystemResumeMonitor()
     {
-        // SystemEvents delivers power notifications on a dedicated broadcast
-        // thread, so no message pump is required in this process.
         SystemEvents.PowerModeChanged += OnPowerModeChanged;
-        return Task.CompletedTask;
     }
 
-    public Task StopAsync(CancellationToken ct)
+    public void Dispose()
     {
         SystemEvents.PowerModeChanged -= OnPowerModeChanged;
-        return Task.CompletedTask;
+        GC.SuppressFinalize(this);
     }
 
     private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
     {
-        if (e.Mode != PowerModes.Resume) return;
-        _logger.LogInformation("System resumed from sleep, notifying manager");
-        // Handle the resume in the background to avoid blocking the shared
-        // SystemEvents broadcast thread. HandleSystemResume logs and swallows
-        // all send failures.
-        _ = Task.Run(() => _manager.HandleSystemResume());
+        if (e.Mode == PowerModes.Resume) Resumed?.Invoke(this, EventArgs.Empty);
     }
 }

--- a/Vpn.Service/SystemResumeMonitor.cs
+++ b/Vpn.Service/SystemResumeMonitor.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Win32;
+
+namespace Coder.Desktop.Vpn.Service;
+
+/// <summary>
+///     Watches for the system resuming from sleep and notifies the manager so it can prompt the tunnel to re-discover
+///     network paths.
+/// </summary>
+public class SystemResumeMonitor : IHostedService
+{
+    private readonly ILogger<SystemResumeMonitor> _logger;
+    private readonly IManager _manager;
+
+    // ReSharper disable once ConvertToPrimaryConstructor
+    public SystemResumeMonitor(ILogger<SystemResumeMonitor> logger, IManager manager)
+    {
+        _logger = logger;
+        _manager = manager;
+    }
+
+    public Task StartAsync(CancellationToken ct)
+    {
+        // SystemEvents delivers power notifications on a dedicated broadcast
+        // thread, so no message pump is required in this process.
+        SystemEvents.PowerModeChanged += OnPowerModeChanged;
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct)
+    {
+        SystemEvents.PowerModeChanged -= OnPowerModeChanged;
+        return Task.CompletedTask;
+    }
+
+    private void OnPowerModeChanged(object sender, PowerModeChangedEventArgs e)
+    {
+        if (e.Mode != PowerModes.Resume) return;
+        _logger.LogInformation("System resumed from sleep, notifying manager");
+        // Handle the resume in the background to avoid blocking the shared
+        // SystemEvents broadcast thread. HandleSystemResume logs and swallows
+        // all send failures.
+        _ = Task.Run(() => _manager.HandleSystemResume());
+    }
+}

--- a/Vpn.Service/TunnelSupervisor.cs
+++ b/Vpn.Service/TunnelSupervisor.cs
@@ -11,6 +11,12 @@ namespace Coder.Desktop.Vpn.Service;
 public interface ITunnelSupervisor : IAsyncDisposable
 {
     /// <summary>
+    ///     The RPC version negotiated with the currently running tunnel. Null if the tunnel is not running or its
+    ///     handshake has not completed yet.
+    /// </summary>
+    public RpcVersion? NegotiatedVersion { get; }
+
+    /// <summary>
     ///     Starts the tunnel subprocess with the given executable path. If the subprocess is already running, this method will
     ///     kill it first.
     /// </summary>
@@ -63,6 +69,8 @@ public class TunnelSupervisor : ITunnelSupervisor
     private AnonymousPipeServerStream? _outPipe;
     private Speaker<ManagerMessage, TunnelMessage>? _speaker;
     private Process? _subprocess;
+
+    public RpcVersion? NegotiatedVersion => _speaker?.NegotiatedVersion;
 
     // ReSharper disable once ConvertToPrimaryConstructor
     public TunnelSupervisor(ILogger<TunnelSupervisor> logger)

--- a/Vpn.Service/TunnelSupervisor.cs
+++ b/Vpn.Service/TunnelSupervisor.cs
@@ -11,8 +11,7 @@ namespace Coder.Desktop.Vpn.Service;
 public interface ITunnelSupervisor : IAsyncDisposable
 {
     /// <summary>
-    ///     The RPC version negotiated with the currently running tunnel. Null if the tunnel is not running or its
-    ///     handshake has not completed yet.
+    ///     The RPC version negotiated with the running tunnel, or null if the tunnel is not running.
     /// </summary>
     public RpcVersion? NegotiatedVersion { get; }
 

--- a/Vpn.Service/Vpn.Service.csproj
+++ b/Vpn.Service/Vpn.Service.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
         <PackageReference Include="Microsoft.Security.Extensions" Version="1.3.0" />
+        <PackageReference Include="Microsoft.Win32.SystemEvents" Version="9.0.4" />
         <PackageReference Include="Semver" Version="3.0.0" />
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />

--- a/Vpn.Service/packages.lock.json
+++ b/Vpn.Service/packages.lock.json
@@ -59,6 +59,12 @@
         "resolved": "1.3.0",
         "contentHash": "xK8WFEo5WMUE8DI8W+GjhRwpVcPrxc4DyTjfxh39+yOyhAtC5TBHDlFEJks5toNZHsUeUuiWELIX25oTWOKPBw=="
       },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Direct",
+        "requested": "[9.0.4, )",
+        "resolved": "9.0.4",
+        "contentHash": "kHgtAkXhNEP8oGuAVe3Q5admxsdMlSdWE2rXcA9FfeGDZJQawPccmZgnOswgW3ugUPSJt7VH+TMQPz65mnhGSQ=="
+      },
       "Semver": {
         "type": "Direct",
         "requested": "[3.0.0, )",

--- a/Vpn/Speaker.cs
+++ b/Vpn/Speaker.cs
@@ -83,6 +83,12 @@ public class Speaker<TS, TR> : IAsyncDisposable
     /// </summary>
     public event OnReceiveDelegate? Receive;
 
+    /// <summary>
+    ///     The RPC version negotiated with the peer. Null until the handshake performed by <c>StartAsync</c> has
+    ///     completed successfully.
+    /// </summary>
+    public RpcVersion? NegotiatedVersion { get; private set; }
+
     private readonly Stream _conn;
 
     // _cts is cancelled when Dispose is called and will cause all ongoing I/O
@@ -157,8 +163,10 @@ public class Speaker<TS, TR> : IAsyncDisposable
         if (header.Role != expectedRole)
             throw new ArgumentException($"Expected peer role '{expectedRole}' but got '{header.Role}'");
 
-        if (header.VersionList.IsCompatibleWith(RpcVersionList.Current) is null)
+        var negotiatedVersion = header.VersionList.IsCompatibleWith(RpcVersionList.Current);
+        if (negotiatedVersion is null)
             throw new RpcVersionCompatibilityException(RpcVersionList.Current, header.VersionList);
+        NegotiatedVersion = negotiatedVersion;
     }
 
     private async Task WriteHeader(CancellationToken ct = default)

--- a/Vpn/Speaker.cs
+++ b/Vpn/Speaker.cs
@@ -84,8 +84,7 @@ public class Speaker<TS, TR> : IAsyncDisposable
     public event OnReceiveDelegate? Receive;
 
     /// <summary>
-    ///     The RPC version negotiated with the peer. Null until the handshake performed by <c>StartAsync</c> has
-    ///     completed successfully.
+    ///     The RPC version negotiated during the handshake. Null until <c>StartAsync</c> completes.
     /// </summary>
     public RpcVersion? NegotiatedVersion { get; private set; }
 


### PR DESCRIPTION
Fixes coder/coder-desktop-windows#172

After the machine sleeps and wakes, the Coder Connect tunnel can stay unusable for several minutes until magicsock's periodic re-STUN recovers the path on its own. The daemon side (coder/coder#26739, tunnel protocol `1.3`) added a `WakeRequest` RPC that forces network path re-discovery on demand. This PR makes the Windows manager emit it on system resume.

## Changes

* `Vpn.Proto/vpn.proto`: synced with upstream `coder/coder`; adds `WakeRequest` / `WakeResponse` (bindings generated at build time).
* `RpcVersion`: `Current` bumped `1.1` -> `1.3`; new `IsAtLeast()` ordered comparison for version-gating.
* `Speaker`: exposes `NegotiatedVersion`, captured during the handshake (previously discarded).
* `TunnelSupervisor`: surfaces the tunnel's `NegotiatedVersion` through `ITunnelSupervisor`.
* `SystemResumeMonitor` (new): event-based class raising `Resumed` from `SystemEvents.PowerModeChanged`; registered as a singleton.
* `Manager`: subscribes to `Resumed` (mirroring the existing `IManagerRpc.OnReceive` wiring) and sends `WakeRequest` when the negotiated version is `>= 1.3`, with a 5s reply timeout. The send is fire-and-forget off the SystemEvents broadcast thread; `SendWakeRequest` logs and swallows all failures by construction, so nothing can fault the discarded task or affect the running tunnel.

## Tests

* `SpeakerTest`: negotiated version exposed after handshake.
* `RpcVersionTest`: `IsAtLeast` ordering.
* `ManagerTest` (new): wake request sent on the resume event; skipped when the tunnel isn't running or the version is too old; send failures are swallowed.

<details><summary>Implementation decisions</summary>

1. `1.2`'s `last_ping` fields were already present in this repo's proto; only the version constant was never bumped, so `Current` goes straight to `1.3`.
2. Resume detection uses `SystemEvents.PowerModeChanged` (as suggested in the issue): works in both service and console mode, and SystemEvents runs its own broadcast window thread so no message pump is needed. The service-control-handler alternative (`CanHandlePowerEvent`/`OnPowerEvent`) requires subclassing `WindowsServiceLifetime` and doesn't fire in console/debug mode.
3. Version gating uses standard ordering (`IsAtLeast`) rather than an exact-major match, so a future major protocol bump keeps sending wake requests.
4. Wake is a unary RPC with a 5s timeout rather than pure fire-and-forget at the RPC layer, so unexpected replies can be logged.
5. The wake gate relies on `NegotiatedVersion == null` to detect a stopped tunnel, keeping `SendWakeRequest` side-effect free and unit-testable with a fake `ITunnelSupervisor`.

</details>

---

*This PR was generated with Coder Agents on behalf of* @EhabY\*.\*